### PR TITLE
Feature/question

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 .env.local
 .env.*.local
+sample/
 
 # ========================
 # Python

--- a/README.md
+++ b/README.md
@@ -120,13 +120,8 @@ AI가 면접관 역할을 수행합니다.
     ./gradlew bootRun
 
   Python AI 서버
+  PS C:\Users\user\Documents\GitHub\gamyeon-AI> uv run uvicorn app.main:app --reload
 
-    git clone https://github.com/your-org/gamyeon-ai.git
-    cd gamyeon-ai
-    cp .env.example .env
-    # .env에 API 키 입력
-    uv sync
-    uv run fastapi dev app/main.py
 
   환경변수 (.env)
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,90 @@ AI가 면접관 역할을 수행합니다.
   Python AI 서버
   PS C:\Users\user\Documents\GitHub\gamyeon-AI> uv run uvicorn app.main:app --reload
 
+### test
+## 테스트 방법
 
+***
+
+**① 서버 실행**
+```bash
+uv run uvicorn app.main:app --reload
+```
+
+***
+
+**② `http://localhost:8000/docs` 접속**
+
+***
+
+**③ `/api/ai/question/generate` 클릭 → `Try it out` 클릭**
+
+***
+
+**④ Request Body 입력**
+
+이력서만 있는 경우:
+```json
+{
+  "resume_url": "sample/resume.pdf",
+  "portfolio_url": null,
+  "self_introduction_url": null,
+  "job_role": "백엔드 개발자"
+}
+```
+
+이력서 + 포트폴리오 있는 경우:
+```json
+{
+  "resume_url": "sample/resume.pdf",
+  "portfolio_url": "sample/portfolio.pdf",
+  "self_introduction_url": null,
+  "job_role": "백엔드 개발자"
+}
+```
+
+이력서 + 포트폴리오 + 자기소개서 모두 있는 경우:
+```json
+{
+  "resume_url": "sample/resume.pdf",
+  "portfolio_url": "sample/portfolio.pdf",
+  "self_introduction_url": "sample/self_introduction.pdf",
+  "job_role": "백엔드 개발자"
+}
+```
+
+***
+
+**⑤ `Execute` 클릭**
+
+***
+
+## 예상 정상 응답
+
+```json
+{
+  "questions": [
+    "백엔드 개발자로서 RESTful API 설계 시 어떤 원칙을 중요하게 생각하시나요?",
+    "PostgreSQL과 MySQL을 모두 사용해보셨는데, 두 DB의 차이점과 각각 어떤 상황에서 선택하셨나요?",
+    "FastAPI와 Express.js를 함께 사용한 경험이 있으신데, 두 프레임워크의 장단점을 비교해주세요.",
+    "클린 아키텍처를 지향하신다고 하셨는데, 실제 프로젝트에서 어떻게 적용하셨나요?"
+  ]
+}
+```
+
+***
+
+**⑥ 파일 경로 주의사항**
+
+`sample/resume.pdf` 경로는 **서버 실행 위치 기준**입니다. 프로젝트 루트에서 서버를 실행했다면 아래 구조여야 합니다.
+
+```
+gamyeon-AI/
+└── sample/
+    ├── resume.pdf        ← 실제 파일 존재 확인
+    ├── portfolio.pdf
+    └── self_introduction.pdf
+```
   환경변수 (.env)
 
     OPENAI_API_KEY=your-openai-api-key

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,11 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    aws_region: str
+    s3_bucket_name: str
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from dotenv import load_dotenv
+from app.question.router import router as question_router
 
 load_dotenv()
 
@@ -8,6 +9,8 @@ app = FastAPI(
     description="AI Interview Simulator - AI Features",
     version="0.1.0"
 )
+
+app.include_router(question_router, prefix="/api/ai")
 
 @app.get("/health")
 def health_check():

--- a/app/question/application/port/pdf_extract_port.py
+++ b/app/question/application/port/pdf_extract_port.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+
+class PdfExtractPort(ABC):
+
+    @abstractmethod
+    async def extract(self, file_bytes: bytes) -> str:
+        """PDF bytes에서 텍스트를 추출하여 반환"""
+        pass

--- a/app/question/application/port/question_gen_port.py
+++ b/app/question/application/port/question_gen_port.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+from app.question.domain.interview_input import InterviewInput
+
+class QuestionGenPort(ABC):
+
+    @abstractmethod
+    async def generate(self, interview_input: InterviewInput) -> list[str]:
+        """InterviewInput을 기반으로 면접 질문 목록을 생성"""
+        pass

--- a/app/question/application/port/s3_download_port.py
+++ b/app/question/application/port/s3_download_port.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+
+class S3DownloadPort(ABC):
+
+    @abstractmethod
+    async def download(self, url: str) -> bytes:
+        """S3 Presigned URL로부터 파일을 다운로드하여 bytes로 반환"""
+        pass

--- a/app/question/application/port/structuring_port.py
+++ b/app/question/application/port/structuring_port.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from app.question.domain.interview_input import InterviewInput
+
+class StructuringPort(ABC):
+
+    @abstractmethod
+    async def structure(
+        self,
+        resume_text: str,
+        job_role: str,
+        portfolio_text: str | None = None,
+        self_intro_text: str | None = None,
+    ) -> InterviewInput:
+        pass

--- a/app/question/application/service.py
+++ b/app/question/application/service.py
@@ -2,7 +2,7 @@ import asyncio
 from app.question.application.port.s3_download_port import S3DownloadPort
 from app.question.application.port.pdf_extract_port import PdfExtractPort
 from app.question.application.port.structuring_port import StructuringPort
-from app.question.domain.interview_input import InterviewInput
+from app.question.application.port.question_gen_port import QuestionGenPort
 from app.question.infrastructure.pymupdf_adapter import MAX_CHARS_RESUME, MAX_CHARS_OTHER
 
 class QuestionService:
@@ -12,10 +12,12 @@ class QuestionService:
         s3_download_port: S3DownloadPort,
         pdf_extract_port: PdfExtractPort,
         structuring_port: StructuringPort,
+        question_gen_port: QuestionGenPort,
     ):
         self.s3_download_port = s3_download_port
         self.pdf_extract_port = pdf_extract_port
         self.structuring_port = structuring_port
+        self.question_gen_port = question_gen_port
 
     async def parse_and_generate(
         self,
@@ -42,19 +44,14 @@ class QuestionService:
         )
 
         # [4단계] LLM 구조화
-        interview_input: InterviewInput = await self.structuring_port.structure(
+        interview_input = await self.structuring_port.structure(
             resume_text=resume_text,
             job_role=job_role,
             portfolio_text=portfolio_text,
             self_intro_text=self_intro_text,
         )
 
-        # 임시 반환 (질문 생성 로직은 다음 단계)
-        return [
-            f"name: {interview_input.name}",
-            f"job_role: {interview_input.job_role}",
-            f"core_competencies: {interview_input.core_competencies}",
-            f"career_summary: {interview_input.career_summary}",
-            f"work_experiences: {interview_input.work_experiences}",
-            f"projects: {interview_input.projects}",
-        ]
+        # [5단계] 질문 생성
+        questions = await self.question_gen_port.generate(interview_input)
+
+        return questions

--- a/app/question/application/service.py
+++ b/app/question/application/service.py
@@ -1,0 +1,45 @@
+import asyncio
+from app.question.application.port.s3_download_port import S3DownloadPort
+from app.question.application.port.pdf_extract_port import PdfExtractPort
+from app.question.infrastructure.pymupdf_adapter import MAX_CHARS_RESUME, MAX_CHARS_OTHER
+# local file version
+class QuestionService:
+
+    def __init__(
+        self,
+        s3_download_port: S3DownloadPort,
+        pdf_extract_port: PdfExtractPort,
+    ):
+        self.s3_download_port = s3_download_port
+        self.pdf_extract_port = pdf_extract_port
+
+    async def parse_and_generate(
+        self,
+        resume_url: str,
+        job_role: str,
+        portfolio_url: str | None = None,
+        self_introduction_url: str | None = None,
+    ) -> list[str]:
+
+        # [1단계] S3 병렬 다운로드
+        resume_bytes, portfolio_bytes, self_intro_bytes = await asyncio.gather(
+            self.s3_download_port.download(resume_url),
+            self.s3_download_port.download(portfolio_url) if portfolio_url else asyncio.sleep(0, result=None),
+            self.s3_download_port.download(self_introduction_url) if self_introduction_url else asyncio.sleep(0, result=None),
+        )
+
+        # [2단계] 이력서 텍스트 추출 (필수, 우선)
+        resume_text = await self.pdf_extract_port.extract(resume_bytes, max_chars=MAX_CHARS_RESUME)
+
+        # [3단계] 선택 파일 병렬 텍스트 추출
+        portfolio_text, self_intro_text = await asyncio.gather(
+            self.pdf_extract_port.extract(portfolio_bytes, max_chars=MAX_CHARS_OTHER) if portfolio_bytes else asyncio.sleep(0, result=None),
+            self.pdf_extract_port.extract(self_intro_bytes, max_chars=MAX_CHARS_OTHER) if self_intro_bytes else asyncio.sleep(0, result=None),
+        )
+
+        # 추출 결과 확인 (임시 반환)
+        return [
+            f"resume_text: {resume_text[:100]}",
+            f"portfolio_text: {portfolio_text[:100] if portfolio_text else 'None'}",
+            f"self_intro_text: {self_intro_text[:100] if self_intro_text else 'None'}",
+        ]

--- a/app/question/application/service.py
+++ b/app/question/application/service.py
@@ -1,17 +1,21 @@
 import asyncio
 from app.question.application.port.s3_download_port import S3DownloadPort
 from app.question.application.port.pdf_extract_port import PdfExtractPort
+from app.question.application.port.structuring_port import StructuringPort
+from app.question.domain.interview_input import InterviewInput
 from app.question.infrastructure.pymupdf_adapter import MAX_CHARS_RESUME, MAX_CHARS_OTHER
-# local file version
+
 class QuestionService:
 
     def __init__(
         self,
         s3_download_port: S3DownloadPort,
         pdf_extract_port: PdfExtractPort,
+        structuring_port: StructuringPort,
     ):
         self.s3_download_port = s3_download_port
         self.pdf_extract_port = pdf_extract_port
+        self.structuring_port = structuring_port
 
     async def parse_and_generate(
         self,
@@ -37,9 +41,20 @@ class QuestionService:
             self.pdf_extract_port.extract(self_intro_bytes, max_chars=MAX_CHARS_OTHER) if self_intro_bytes else asyncio.sleep(0, result=None),
         )
 
-        # 추출 결과 확인 (임시 반환)
+        # [4단계] LLM 구조화
+        interview_input: InterviewInput = await self.structuring_port.structure(
+            resume_text=resume_text,
+            job_role=job_role,
+            portfolio_text=portfolio_text,
+            self_intro_text=self_intro_text,
+        )
+
+        # 임시 반환 (질문 생성 로직은 다음 단계)
         return [
-            f"resume_text: {resume_text[:100]}",
-            f"portfolio_text: {portfolio_text[:100] if portfolio_text else 'None'}",
-            f"self_intro_text: {self_intro_text[:100] if self_intro_text else 'None'}",
+            f"name: {interview_input.name}",
+            f"job_role: {interview_input.job_role}",
+            f"core_competencies: {interview_input.core_competencies}",
+            f"career_summary: {interview_input.career_summary}",
+            f"work_experiences: {interview_input.work_experiences}",
+            f"projects: {interview_input.projects}",
         ]

--- a/app/question/domain/interview_input.py
+++ b/app/question/domain/interview_input.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+class InterviewInput(BaseModel):
+    name: str                                    # 필수
+    job_role: str                                # 필수 (요청값 그대로 사용)
+    core_competencies: list[str] = []            # 직군 무관 핵심 역량 목록
+    career_summary: str | None = None            # 경력 한줄 요약
+    work_experiences: list[str] = []             # 주요 경력 목록
+    projects: list[str] = []                     # 프로젝트/작업물 요약 목록
+    portfolio_summary: str | None = None         # 포트폴리오 요약
+    self_introduction_summary: str | None = None # 자기소개서 요약

--- a/app/question/infrastructure/di.py
+++ b/app/question/infrastructure/di.py
@@ -1,0 +1,21 @@
+from app.question.application.port.s3_download_port import S3DownloadPort
+from app.question.application.port.pdf_extract_port import PdfExtractPort
+from app.question.infrastructure.local_file_adapter import LocalFileAdapter
+from app.question.infrastructure.pymupdf_adapter import PyMuPDFAdapter
+#local file adapter로 s3 연결전 파일 읽어오는 어댑터로 사용
+def get_s3_download_port() -> S3DownloadPort:
+    return LocalFileAdapter()
+
+def get_pdf_extract_port() -> PdfExtractPort:
+    return PyMuPDFAdapter()
+
+
+"""   
+
+#원본
+from app.question.application.port.s3_download_port import S3DownloadPort
+from app.question.infrastructure.s3_download_adapter import S3DownloadAdapter
+
+def get_s3_download_port() -> S3DownloadPort:
+    return S3DownloadAdapter()
+"""

--- a/app/question/infrastructure/di.py
+++ b/app/question/infrastructure/di.py
@@ -1,13 +1,19 @@
 from app.question.application.port.s3_download_port import S3DownloadPort
 from app.question.application.port.pdf_extract_port import PdfExtractPort
+from app.question.application.port.structuring_port import StructuringPort
 from app.question.infrastructure.local_file_adapter import LocalFileAdapter
 from app.question.infrastructure.pymupdf_adapter import PyMuPDFAdapter
-#local file adapter로 s3 연결전 파일 읽어오는 어댑터로 사용
+from app.question.infrastructure.llm_structuring_adapter import LLMStructuringAdapter
+
 def get_s3_download_port() -> S3DownloadPort:
     return LocalFileAdapter()
 
 def get_pdf_extract_port() -> PdfExtractPort:
     return PyMuPDFAdapter()
+
+def get_structuring_port() -> StructuringPort:
+    return LLMStructuringAdapter()
+
 
 
 """   

--- a/app/question/infrastructure/di.py
+++ b/app/question/infrastructure/di.py
@@ -1,9 +1,11 @@
 from app.question.application.port.s3_download_port import S3DownloadPort
 from app.question.application.port.pdf_extract_port import PdfExtractPort
 from app.question.application.port.structuring_port import StructuringPort
+from app.question.application.port.question_gen_port import QuestionGenPort
 from app.question.infrastructure.local_file_adapter import LocalFileAdapter
 from app.question.infrastructure.pymupdf_adapter import PyMuPDFAdapter
 from app.question.infrastructure.llm_structuring_adapter import LLMStructuringAdapter
+from app.question.infrastructure.llm_question_gen_adapter import LLMQuestionGenAdapter
 
 def get_s3_download_port() -> S3DownloadPort:
     return LocalFileAdapter()
@@ -14,6 +16,8 @@ def get_pdf_extract_port() -> PdfExtractPort:
 def get_structuring_port() -> StructuringPort:
     return LLMStructuringAdapter()
 
+def get_question_gen_port() -> QuestionGenPort:
+    return LLMQuestionGenAdapter()
 
 
 """   

--- a/app/question/infrastructure/llm_question_gen_adapter.py
+++ b/app/question/infrastructure/llm_question_gen_adapter.py
@@ -1,0 +1,21 @@
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from app.question.application.port.question_gen_port import QuestionGenPort
+from app.question.domain.interview_input import InterviewInput
+from app.question.infrastructure.prompts.question_gen_prompt import SYSTEM_PROMPT, build_question_prompt
+
+class LLMQuestionGenAdapter(QuestionGenPort):
+
+    def __init__(self):
+        llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.8)
+        prompt = ChatPromptTemplate.from_messages([
+            ("system", SYSTEM_PROMPT),
+            ("human", "{input}"),
+        ])
+        self.chain = prompt | llm | StrOutputParser()
+
+    async def generate(self, interview_input: InterviewInput) -> list[str]:
+        result = await self.chain.ainvoke({"input": build_question_prompt(interview_input)})
+        questions = [q.strip() for q in result.split("\n") if q.strip()]
+        return questions[:4]  # 혹시 4개 초과 시 안전장치

--- a/app/question/infrastructure/llm_structuring_adapter.py
+++ b/app/question/infrastructure/llm_structuring_adapter.py
@@ -1,0 +1,26 @@
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from app.question.application.port.structuring_port import StructuringPort
+from app.question.domain.interview_input import InterviewInput
+from app.question.infrastructure.prompts.structuring_prompt import SYSTEM_PROMPT, build_human_prompt
+
+class LLMStructuringAdapter(StructuringPort):
+
+    def __init__(self):
+        llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.0)
+        self.chain = llm.with_structured_output(InterviewInput)
+
+    async def structure(
+        self,
+        resume_text: str,
+        job_role: str,
+        portfolio_text: str | None = None,
+        self_intro_text: str | None = None,
+    ) -> InterviewInput:
+        human_prompt = build_human_prompt(resume_text, job_role, portfolio_text, self_intro_text)
+        prompt = ChatPromptTemplate.from_messages([
+            ("system", SYSTEM_PROMPT),
+            ("human", "{input}"),
+        ])
+        chain = prompt | self.chain
+        return await chain.ainvoke({"input": human_prompt})

--- a/app/question/infrastructure/local_file_adapter.py
+++ b/app/question/infrastructure/local_file_adapter.py
@@ -1,0 +1,15 @@
+
+"""
+    s3 연결전 로컬로 파일을 읽어오는 어댑터
+    
+
+ """
+from random import sample
+
+from app.question.application.port.s3_download_port import S3DownloadPort
+
+class LocalFileAdapter(S3DownloadPort):
+
+    async def download(self, url: str ) -> bytes:
+        with open(url, "rb") as f:
+            return f.read()

--- a/app/question/infrastructure/prompts/question_gen_prompt.py
+++ b/app/question/infrastructure/prompts/question_gen_prompt.py
@@ -1,0 +1,35 @@
+SYSTEM_PROMPT = """
+당신은 채용 면접관입니다.
+지원자의 정보를 바탕으로 맞춤형 면접 질문을 생성하세요.
+
+규칙:
+- 반드시 총 4개의 질문을 생성하세요.
+- 제공된 정보가 풍부한 영역에 질문을 더 배분하세요.
+- 제공되지 않은 항목(없음으로 표시된 항목)은 질문에서 제외하세요.
+- 질문은 지원자의 실제 경험에 기반한 구체적인 질문이어야 합니다.
+- 질문 번호나 prefix 없이 질문만 한 줄씩 반환하세요.
+"""
+
+def build_question_prompt(interview_input) -> str:
+    lines = [f"지원 직군: {interview_input.job_role}"]
+
+    if interview_input.core_competencies:
+        lines.append(f"핵심 역량: {', '.join(interview_input.core_competencies)}")
+
+    if interview_input.career_summary:
+        lines.append(f"경력 요약: {interview_input.career_summary}")
+
+    if interview_input.work_experiences:
+        lines.append(f"주요 경력:\n" + "\n".join(interview_input.work_experiences))
+
+    if interview_input.projects:
+        lines.append(f"프로젝트:\n" + "\n".join(interview_input.projects))
+
+    if interview_input.portfolio_summary:
+        lines.append(f"포트폴리오 요약: {interview_input.portfolio_summary}")
+
+    if interview_input.self_introduction_summary:
+        lines.append(f"자기소개서 요약: {interview_input.self_introduction_summary}")
+
+    lines.append("\n위 정보를 바탕으로 맞춤형 면접 질문 4개를 생성하세요.")
+    return "\n\n".join(lines)

--- a/app/question/infrastructure/prompts/structuring_prompt.py
+++ b/app/question/infrastructure/prompts/structuring_prompt.py
@@ -1,0 +1,28 @@
+SYSTEM_PROMPT = """
+당신은 이력서/포트폴리오/자기소개서 텍스트를 분석하여
+지정된 JSON 구조로 변환하는 전문가입니다.
+
+규칙:
+- 텍스트에 없는 내용은 null 또는 빈 리스트로 채우세요.
+- name과 job_role은 반드시 추출하세요.
+- career_summary는 지원자의 경력/역량을 공백포함 3문장이하로 요약하세요.
+- work_experiences는 각 경력을 한 줄씩 요약하세요.
+- projects는 각 프로젝트를 한 줄씩 요약하세요.
+- core_competencies는 직군 무관하게 핵심 역량/기술을 추출하세요.
+"""
+
+def build_human_prompt(
+    resume_text: str,
+    job_role: str,
+    portfolio_text: str | None = None,
+    self_intro_text: str | None = None,
+) -> str:
+    prompt = f"[이력서]\n{resume_text}\n\n"
+    prompt += f"[지원 직군]\n{job_role}\n\n"
+
+    if portfolio_text:
+        prompt += f"[포트폴리오]\n{portfolio_text}\n\n"
+    if self_intro_text:
+        prompt += f"[자기소개서]\n{self_intro_text}\n\n"
+
+    return prompt

--- a/app/question/infrastructure/pymupdf_adapter.py
+++ b/app/question/infrastructure/pymupdf_adapter.py
@@ -1,0 +1,17 @@
+import fitz
+from app.question.application.port.pdf_extract_port import PdfExtractPort
+
+MAX_CHARS_RESUME = 3000
+MAX_CHARS_OTHER = 2000
+
+class PyMuPDFAdapter(PdfExtractPort):
+
+    async def extract(self, file_bytes: bytes, max_chars: int = MAX_CHARS_RESUME) -> str:
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+        text = "\n".join([page.get_text() for page in doc])
+        doc.close()
+
+        if not text.strip():
+            raise ValueError("텍스트 추출 실패: 스캔본 PDF이거나 텍스트가 없습니다.")
+
+        return text[:max_chars]

--- a/app/question/infrastructure/s3_download_adapter.py
+++ b/app/question/infrastructure/s3_download_adapter.py
@@ -1,0 +1,23 @@
+import aioboto3
+from app.question.application.port.s3_download_port import S3DownloadPort
+from app.core.config import settings
+
+class S3DownloadAdapter(S3DownloadPort):
+
+    async def download(self, url: str) -> bytes:
+        session = aioboto3.Session()
+        async with session.client(
+            "s3",
+            region_name=settings.aws_region,
+            aws_access_key_id=settings.aws_access_key_id,
+            aws_secret_access_key=settings.aws_secret_access_key,
+        ) as client:
+            bucket, key = self._parse_url(url)
+            response = await client.get_object(Bucket=bucket, Key=key)
+            return await response["Body"].read()
+
+    def _parse_url(self, url: str) -> tuple[str, str]:
+        # s3://bucket-name/path/to/file.pdf
+        path = url.replace("s3://", "")
+        bucket, key = path.split("/", 1)
+        return bucket, key

--- a/app/question/router.py
+++ b/app/question/router.py
@@ -1,11 +1,25 @@
-from fastapi import APIRouter
-from .schema import QuestionGenerateRequest, QuestionGenerateResponse
-from .service import QuestionService
+from fastapi import APIRouter, HTTPException
+from app.question.schema.request import QuestionGenerateRequest
+from app.question.schema.response import QuestionGenerateResponse
+from app.question.infrastructure.di import get_s3_download_port
+from app.question.infrastructure.di import get_pdf_extract_port
+from app.question.application.service import QuestionService
 
 router = APIRouter(prefix="/question", tags=["question"])
-service = QuestionService()
 
 @router.post("/generate", response_model=QuestionGenerateResponse)
 async def generate_question(request: QuestionGenerateRequest):
-    question = await service.generate(request.job_role, request.resume)
-    return QuestionGenerateResponse(question=question)
+    service = QuestionService(
+        s3_download_port=get_s3_download_port(),
+        pdf_extract_port=get_pdf_extract_port(),
+    )
+    questions = await service.parse_and_generate(
+        resume_url=request.resume_url,
+        job_role=request.job_role,
+        portfolio_url=request.portfolio_url,
+        self_introduction_url=request.self_introduction_url,
+    )
+    return QuestionGenerateResponse(questions=questions)
+
+
+

--- a/app/question/router.py
+++ b/app/question/router.py
@@ -9,7 +9,7 @@ from app.question.infrastructure.di import (
 )
 from app.question.application.service import QuestionService
 
-router = APIRouter(prefix="/question", tags=["question"])
+router = APIRouter(prefix="/internal/v1/question", tags=["question"])
 
 @router.post("/generate", response_model=QuestionGenerateResponse)
 async def generate_question(request: QuestionGenerateRequest):

--- a/app/question/router.py
+++ b/app/question/router.py
@@ -10,9 +10,10 @@ router = APIRouter(prefix="/question", tags=["question"])
 @router.post("/generate", response_model=QuestionGenerateResponse)
 async def generate_question(request: QuestionGenerateRequest):
     service = QuestionService(
-        s3_download_port=get_s3_download_port(),
-        pdf_extract_port=get_pdf_extract_port(),
-    )
+    s3_download_port=get_s3_download_port(),
+    pdf_extract_port=get_pdf_extract_port(),
+    structuring_port=get_structuring_port(),
+)
     questions = await service.parse_and_generate(
         resume_url=request.resume_url,
         job_role=request.job_role,
@@ -20,6 +21,9 @@ async def generate_question(request: QuestionGenerateRequest):
         self_introduction_url=request.self_introduction_url,
     )
     return QuestionGenerateResponse(questions=questions)
+
+from app.question.infrastructure.di import get_s3_download_port, get_pdf_extract_port, get_structuring_port
+
 
 
 

--- a/app/question/router.py
+++ b/app/question/router.py
@@ -1,8 +1,12 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from app.question.schema.request import QuestionGenerateRequest
 from app.question.schema.response import QuestionGenerateResponse
-from app.question.infrastructure.di import get_s3_download_port
-from app.question.infrastructure.di import get_pdf_extract_port
+from app.question.infrastructure.di import (
+    get_s3_download_port,
+    get_pdf_extract_port,
+    get_structuring_port,
+    get_question_gen_port,
+)
 from app.question.application.service import QuestionService
 
 router = APIRouter(prefix="/question", tags=["question"])
@@ -10,10 +14,11 @@ router = APIRouter(prefix="/question", tags=["question"])
 @router.post("/generate", response_model=QuestionGenerateResponse)
 async def generate_question(request: QuestionGenerateRequest):
     service = QuestionService(
-    s3_download_port=get_s3_download_port(),
-    pdf_extract_port=get_pdf_extract_port(),
-    structuring_port=get_structuring_port(),
-)
+        s3_download_port=get_s3_download_port(),
+        pdf_extract_port=get_pdf_extract_port(),
+        structuring_port=get_structuring_port(),
+        question_gen_port=get_question_gen_port(),
+    )
     questions = await service.parse_and_generate(
         resume_url=request.resume_url,
         job_role=request.job_role,
@@ -21,9 +26,3 @@ async def generate_question(request: QuestionGenerateRequest):
         self_introduction_url=request.self_introduction_url,
     )
     return QuestionGenerateResponse(questions=questions)
-
-from app.question.infrastructure.di import get_s3_download_port, get_pdf_extract_port, get_structuring_port
-
-
-
-

--- a/app/question/schema.py
+++ b/app/question/schema.py
@@ -1,8 +1,0 @@
-from pydantic import BaseModel
-
-class QuestionGenerateRequest(BaseModel):
-    job_role: str
-    resume: str
-
-class QuestionGenerateResponse(BaseModel):
-    question: str

--- a/app/question/schema/request.py
+++ b/app/question/schema/request.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class QuestionGenerateRequest(BaseModel):
+    resume_url: str
+    portfolio_url: str | None = None
+    self_introduction_url: str | None = None
+    job_role: str

--- a/app/question/schema/response.py
+++ b/app/question/schema/response.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class QuestionGenerateResponse(BaseModel):
+    questions: list[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,14 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "aioboto3>=15.5.0",
     "fastapi[standard]>=0.133.1",
     "langchain>=1.2.10",
     "langchain-community>=0.4.1",
     "langchain-openai>=1.1.10",
     "langgraph>=1.0.9",
     "pydantic-settings>=2.13.1",
+    "pymupdf>=1.27.1",
     "python-dotenv>=1.2.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,51 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aioboto3"
+version = "15.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiobotocore", extra = ["boto3"] },
+    { name = "aiofiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/01/92e9ab00f36e2899315f49eefcd5b4685fbb19016c7f19a9edf06da80bb0/aioboto3-15.5.0.tar.gz", hash = "sha256:ea8d8787d315594842fbfcf2c4dce3bac2ad61be275bc8584b2ce9a3402a6979", size = 255069, upload-time = "2025-10-30T13:37:16.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/3e/e8f5b665bca646d43b916763c901e00a07e40f7746c9128bdc912a089424/aioboto3-15.5.0-py3-none-any.whl", hash = "sha256:cc880c4d6a8481dd7e05da89f41c384dbd841454fc1998ae25ca9c39201437a6", size = 35913, upload-time = "2025-10-30T13:37:14.549Z" },
+]
+
+[[package]]
+name = "aiobotocore"
+version = "2.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aioitertools" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "multidict" },
+    { name = "python-dateutil" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/94/2e4ec48cf1abb89971cb2612d86f979a6240520f0a659b53a43116d344dc/aiobotocore-2.25.1.tar.gz", hash = "sha256:ea9be739bfd7ece8864f072ec99bb9ed5c7e78ebb2b0b15f29781fbe02daedbc", size = 120560, upload-time = "2025-10-28T22:33:21.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/d275ec4ce5cd0096665043995a7d76f5d0524853c76a3d04656de49f8808/aiobotocore-2.25.1-py3-none-any.whl", hash = "sha256:eb6daebe3cbef5b39a0bb2a97cffbe9c7cb46b2fcc399ad141f369f3c2134b1f", size = 86039, upload-time = "2025-10-28T22:33:19.949Z" },
+]
+
+[package.optional-dependencies]
+boto3 = [
+    { name = "boto3" },
+]
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -138,6 +183,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -207,6 +261,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.40.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/24/3bf865b07d15fea85b63504856e137029b6acbc73762496064219cdb265d/boto3-1.40.61-py3-none-any.whl", hash = "sha256:6b9c57b2a922b5d8c17766e29ed792586a818098efe84def27c8f582b33f898c", size = 139321, upload-time = "2025-10-28T19:26:55.007Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.40.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/c5/f6ce561004db45f0b847c2cd9b19c67c6bf348a82018a48cb718be6b58b0/botocore-1.40.61-py3-none-any.whl", hash = "sha256:17ebae412692fd4824f99cde0f08d50126dc97954008e5ba2b522eb049238aa7", size = 14055973, upload-time = "2025-10-28T19:26:42.15Z" },
 ]
 
 [[package]]
@@ -699,12 +781,14 @@ name = "gamyeon-ai"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "aioboto3" },
     { name = "fastapi", extra = ["standard"] },
     { name = "langchain" },
     { name = "langchain-community" },
     { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "pydantic-settings" },
+    { name = "pymupdf" },
     { name = "python-dotenv" },
 ]
 
@@ -718,12 +802,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aioboto3", specifier = ">=15.5.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.133.1" },
     { name = "langchain", specifier = ">=1.2.10" },
     { name = "langchain-community", specifier = ">=0.4.1" },
     { name = "langchain-openai", specifier = ">=1.1.10" },
     { name = "langgraph", specifier = ">=1.0.9" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "pymupdf", specifier = ">=1.27.1" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
 ]
 
@@ -1003,6 +1089,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2081,6 +2176,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pymupdf"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/0c/40dda0cc4bd2220a2ef75f8c53dd7d8ed1e29681fcb3df75db6ee9677a7e/pymupdf-1.27.1.tar.gz", hash = "sha256:4afbde0769c336717a149ab0de3330dcb75378f795c1a8c5af55c1a628b17d55", size = 85303479, upload-time = "2026-02-12T08:29:17.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/19/fde6ea4712a904b65e8f41124a0e4233879b87a770fe6a8ce857964de6d5/pymupdf-1.27.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bee9f95512f9556dbf2cacfd1413c61b29a55baa07fa7f8fc83d221d8419888a", size = 23986707, upload-time = "2026-02-11T15:03:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c2/070dff91ad3f1bc16fd6c6ceff23495601fcce4c92d28be534417596418a/pymupdf-1.27.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3de95a0889395b0966fafd11b94980b7543a816e89dd1c218597a08543ac3415", size = 23263493, upload-time = "2026-02-11T15:03:45.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/937377f4b3e0fbf6273c17436a49f7db17df1a46b1be9e26653b6fafc0e1/pymupdf-1.27.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2c9d9353b840040cbc724341f4095fb7e2cc1a12a9147d0ec1a0a79f5d773147", size = 24317651, upload-time = "2026-02-11T22:33:38.967Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d5/c701cf2d0cdd6e5d6bca3ca9188d7f5d7ce3ae67dd1368d658cd4bae2707/pymupdf-1.27.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:aeaed76e72cbc061149a825ab0811c5f4752970c56591c2938c5042ec06b26e1", size = 24945742, upload-time = "2026-02-11T15:04:06.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/29/690202b38b93cf77b73a29c25a63a2b6f3fcb36b1f75006e50b8dee7c108/pymupdf-1.27.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f1837554134fb45d390a44de8844b2ca9b6c901c82ccc90b340e3b7f3b126ca", size = 25167965, upload-time = "2026-02-11T22:36:35.478Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/81/f937e6aa606fd263c3a45d0ff0f0bbdbf3fb779933091fc0f6179513cc93/pymupdf-1.27.1-cp310-abi3-win32.whl", hash = "sha256:fa33b512d82c6c4852edadf57f22d5f27d16243bb33dac0fbe4eb0f281c5b17e", size = 18006253, upload-time = "2026-02-12T13:48:07.129Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/99/fe4a7752990bf65277718fffbead4478de9afd1c7288d7a6d643f79a6fa7/pymupdf-1.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:4b6268dff3a9d713034eba5c2ffce0da37c62443578941ac5df433adcde57b2f", size = 19236703, upload-time = "2026-02-11T15:04:19.607Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2110,6 +2220,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -2516,6 +2638,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2535,6 +2669,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -3080,6 +3223,75 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04", size = 53482, upload-time = "2025-08-12T05:51:44.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/69/f3c47642b79485a30a59c63f6d739ed779fb4cc8323205d047d741d55220/wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2", size = 38676, upload-time = "2025-08-12T05:51:32.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/71/e7e7f5670c1eafd9e990438e69d8fb46fa91a50785332e06b560c869454f/wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c", size = 38957, upload-time = "2025-08-12T05:51:54.655Z" },
+    { url = "https://files.pythonhosted.org/packages/de/17/9f8f86755c191d6779d7ddead1a53c7a8aa18bccb7cea8e7e72dfa6a8a09/wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775", size = 81975, upload-time = "2025-08-12T05:52:30.109Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/15/dd576273491f9f43dd09fce517f6c2ce6eb4fe21681726068db0d0467096/wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd", size = 83149, upload-time = "2025-08-12T05:52:09.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c4/5eb4ce0d4814521fee7aa806264bf7a114e748ad05110441cd5b8a5c744b/wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05", size = 82209, upload-time = "2025-08-12T05:52:10.331Z" },
+    { url = "https://files.pythonhosted.org/packages/31/4b/819e9e0eb5c8dc86f60dfc42aa4e2c0d6c3db8732bce93cc752e604bb5f5/wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418", size = 81551, upload-time = "2025-08-12T05:52:31.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/83/ed6baf89ba3a56694700139698cf703aac9f0f9eb03dab92f57551bd5385/wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390", size = 36464, upload-time = "2025-08-12T05:53:01.204Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/ee61d36862340ad7e9d15a02529df6b948676b9a5829fd5e16640156627d/wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6", size = 38748, upload-time = "2025-08-12T05:53:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c3/cefe0bd330d389c9983ced15d326f45373f4073c9f4a8c2f99b50bfea329/wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18", size = 36810, upload-time = "2025-08-12T05:52:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📌 작업 개요
Spring → Python AI 서버 간 내부 API(`/internal/v1/question/generate`)에서, 이력서/포트폴리오/자기소개서 PDF를 기반으로 맞춤형 면접 질문 4개를 생성하는 **질문 생성 기능 Question feature 1차 구현 및 API 컨벤션 정합성 반영** 작업입니다.

***

## 📑 작업 사항 (Checklist)
- [x] Base branch(develop/main)의 최신 내용을 반영(Rebase)했는가?
- [x] **새로운 패키지를 설치했다면 requirements.txt 또는 pyproject.toml에 반영했는가?**  
  - `aioboto3`, `pymupdf`, `langchain`, `langchain-openai`, `pydantic-settings` 추가
- [x] **비동기 함수(async def) 사용 시 await 키워드가 누락되지 않았는가?**  
  - `download`, `extract`, LLM 호출(`ainvoke`), `asyncio.gather` 모두 `await` 적용
- [x] **Pytest를 통해 유닛 테스트 및 API 동작 성공을 확인했는가?**  
  - 로컬 환경에서 `/internal/v1/question/generate` 엔드포인트 수동 테스트 (Swagger UI)로 정상 응답 확인
- [x] **Pydantic 모델의 타입 힌트와 명세가 일치하는가?**  
  - `InterviewInput`, Request/Response 스키마, 공통 응답 래퍼 타입 힌트 점검

***

## 📸 스크린샷 / 결과물

#### [AS-IS]
- Python AI 서버 내 Question 기능은 초기 스캐폴딩 수준으로 존재
  - `app/question/router.py`  
    - 경로: `/question/generate`  
    - 단순 텍스트 기반 질문 생성 (LLM 구조화/질문 생성 파이프라인 미구현)
  - `schema.py` 하나에 Request/Response 통합, 공통 응답 포맷 미적용
  - S3 연동, PDF 텍스트 추출, LLM 구조화/질문 생성 Port/Adapter 미구현
- Spring ↔ Python 간 API 컨벤션(`internal`, 공통 Response 포맷) 미적용

#### [TO-BE]
1. **엔드포인트 정합성**
   - 경로: `/internal/v1/question/generate`
   - 용도: Spring → Python AI 서버 간 내부 질문 생성 호출

2. **공통 응답 포맷 적용**
   - 성공 응답 예시:
     ```json
     {
       "success": true,
       "code": "S000",
       "message": "success",
       "data": {
         "questions": [
           "서버 프로그래밍과 데이터베이스 설계에 대한 기초 지식을 가지고 계신데, 실제로 프로젝트에서 어떤 기술 스택을 사용하였는지 그리고 그 선택의 이유는 무엇인지 설명해 주실 수 있나요?",
           "AI 기반 학원 데스크 업무 자동화 프로젝트에서 구현한 학생별 코멘트 생성 및 SMS 전송 기능에 대해 구체적으로 어떤 기술적 도전이 있었고, 이를 어떻게 해결했는지 이야기해 주시겠어요?",
           "뮤지컬 알림 서비스에서 맞춤형 티켓 오픈 알림 시스템을 설계하고 배포하셨다고 하셨는데, 이 과정에서 데이터베이스 설계는 어떻게 진행하였으며, 어떤 점을 중점적으로 고려하셨는지 궁금합니다.",
           "효율적인 시스템 구축에 관심이 많다고 하셨습니다. 이를 위해 그동안 어떤 방식으로 시스템 아키텍처를 설계하고 유지보수성을 높이기 위한 노력을 기울였는지 구체적인 경험을 나눠 주실 수 있나요?"
         ]
       },
       "errors": null
     }
     ```

3. **도메인 모델 및 포트/어댑터 구조 구현 (Half Hexagonal 준수)**

   - `app/question/domain/interview_input.py`
     - LLM 구조화 결과를 담는 도메인 모델
     - 필드:
       - `name: str`
       - `job_role: str`
       - `core_competencies: list[str] = []`
       - `career_summary: str | None = None`
       - `work_experiences: list[str] = []`
       - `projects: list[str] = []`
       - `portfolio_summary: str | None = None`
       - `self_introduction_summary: str | None = None`

   - `app/question/application/port/`
     - `S3DownloadPort`: 파일 경로(추후 S3 URL) → bytes
     - `PdfExtractPort`: PDF bytes → 텍스트
     - `StructuringPort`: 텍스트 → `InterviewInput`
     - `QuestionGenPort`: `InterviewInput` → 질문 리스트

   - `app/question/infrastructure/`
     - `local_file_adapter.py`  
       - 개발 단계용: 로컬 경로에서 파일을 읽어 `bytes` 반환
     - `pymupdf_adapter.py`  
       - PyMuPDF(fitz)를 사용해 PDF에서 텍스트 추출  
       - 이력서: 최대 3,000자, 그 외: 최대 2,000자
     - `prompts/structuring_prompt.py`  
       - 구조화용 시스템 프롬프트 및 동적 휴먼 프롬프트 빌더
     - `llm_structuring_adapter.py`  
       - `gpt-4o-mini`, `temperature=0.0`  
       - LangChain `with_structured_output(InterviewInput)`로 JSON 구조화
     - `prompts/question_gen_prompt.py`  
       - 총 4개의 맞춤형 질문 생성, 정보가 풍부한 영역에 비중을 더 두도록 프롬프트 설계
     - `llm_question_gen_adapter.py`  
       - `gpt-4o-mini`, `temperature=0.8`  
       - 단일 프롬프트 호출로 질문 4개 생성 (line split 후 4개로 제한)
     - `di.py`  
       - 위 Port–Adapter 매핑 (현재는 `LocalFileAdapter` 사용, S3 키 수령 시 `S3DownloadAdapter`로 교체 예정)

4. **애플리케이션 서비스 레이어 구현**

   - `app/question/application/service.py`
     - `parse_and_generate(...)` 유스케이스:
       1. (현재는 Local) 파일 다운로드 (추후 S3 Presigned URL 기반 다운로드로 전환)
       2. 이력서 텍스트 우선 추출 → 실패 시 422 반환 대상으로 사용 가능
       3. 포트폴리오/자소서 텍스트 병렬 추출 (있을 경우)
       4. 구조화 LLM 호출 → `InterviewInput` 생성
       5. 질문 생성 LLM 호출 → 맞춤형 질문 4개 생성
       6. 질문 리스트 반환

5. **라우터 및 엔드포인트 정리**

   - `app/question/router.py`
     - `APIRouter(prefix="/internal/v1/question", tags=["question"])`
     - `POST /internal/v1/question/generate`
     - 요청: `QuestionGenerateRequest` (resume/portfolio/self_intro URL + job_role)
     - 응답: 공통 `ApiResponse` 래퍼 (`data={"questions": [...]}`)

6. **공통 응답 래퍼 도입 (Python 측)**

   - (제안) `app/common/response.py`  
     - `ApiResponse` Pydantic 모델
     - `success_response`, `error_response` 헬퍼
   - 현재 PR에서는 질문 API에 바로 맞는 형태로 응답을 구성했으며, 필요 시 공통 모듈로 분리 가능

***

## 🧪 테스트 결과

- **테스트 환경**:
  - macOS / Windows (로컬)
  - FastAPI + Uvicorn (`http://localhost:8000/docs`)
  - OpenAI API Key 설정된 `.env`
  - 로컬 PDF 파일 (`sample/resume.pdf` 등)

- **테스트 내용**:
  1. `/health` 헬스 체크 정상 응답
  2. `/internal/v1/question/generate`  
     - Request Body:
       ```json
       {
         "resume_url": "sample/resume.pdf",
         "portfolio_url": null,
         "self_introduction_url": null,
         "job_role": "백엔드 개발자"
       }
       ```
     - 응답:
       - `success=true`
       - `code="S000"`
       - `data.questions` 배열 길이 4개
       - 각 질문이 실제 이력서 내용(경력, 프로젝트, 자기소개 텍스트)을 반영하고 있음
       -  {
  "questions": [
    "서버 프로그래밍과 데이터베이스 설계에 대한 기초 지식을 바탕으로, 실제 프로젝트에서 어떤 기술 스택을 사용했는지 구체적으로 설명해 주실 수 있나요?",
    "'EduMate' 프로젝트에서 AI 에이전트를 설계하면서 겪었던 가장 큰 도전 과제는 무엇이었으며, 이를 어떻게 해결하셨나요?",
    "뮤지컬 알림 서비스 'MURE'에서 KOPIS OpenAPI를 연동할 때 API 설계와 문서화 과정에서 중요하게 생각했던 점은 무엇인가요?",
    "효율적인 시스템 설계를 위해 유지보수성과 확장을 고려한다고 하셨는데, 이전 프로젝트에서 이러한 측면을 어떻게 반영했는지 구체적인 사례를 들어 설명해 주실 수 있나요?"
  ]
}

약 10초 내외 

***


