### PR TITLE
[media] 아웃바운드 포트 정의

### DIFF
--- a/app/media/application/port/__init__.py
+++ b/app/media/application/port/__init__.py
@@ -1,0 +1,20 @@
+"""
+media 모듈 아웃바운드 포트 진입점.
+
+포트 목록:
+STTPort                  ← S4 STT 엔진 추상화
+TranscriptCorrectionPort ← S5 LLM CoT 교정 추상화
+GazeBufferPort           ← Gaze 세그먼트 큐 추상화
+ScoringConfigPort        ← Consul KV 정책 조회 추상화
+"""
+
+from .stt_port            import STTPort, TranscriptCorrectionPort
+from .gaze_buffer_port    import GazeBufferPort
+from .scoring_config_port import ScoringConfigPort
+
+__all__ = [
+    "STTPort",
+    "TranscriptCorrectionPort",
+    "GazeBufferPort",
+    "ScoringConfigPort",
+]

--- a/app/media/application/port/gaze_buffer_port.py
+++ b/app/media/application/port/gaze_buffer_port.py
@@ -1,0 +1,85 @@
+from abc import ABC, abstractmethod
+
+from media.domain import GazeSegment
+
+
+class GazeBufferPort(ABC) :
+    """
+    Gaze 세그먼트 큐 추상화 포트.
+
+    흐름:
+      수신 시점 (답변 중):
+        POST /internal/media/gaze/segment 수신
+        → push() 호출
+        → questionId 기준 버퍼에 segmentSequence 정렬 삽입
+
+      처리 시점 (답변 종료):
+        POST /internal/media/process 수신
+        → pop_all() 호출
+        → 정렬된 전체 세그먼트 반환 + 버퍼 제거
+        → GazeAggregator.aggregate() 입력
+    """
+
+    @abstractmethod
+    async def push(self, segment: GazeSegment) -> None :
+        """
+        세그먼트 버퍼 적재.
+
+        Args:
+            segment: 수신된 GazeSegment (raw_data[] 포함 전체)
+
+        Note:
+            segmentSequence 기준 정렬 삽입 보장.
+            동일 questionId + segmentSequence 중복 수신 시
+            마지막 수신 데이터로 덮어씀 (last-write-wins).
+        """
+        ...
+
+    @abstractmethod
+    async def pop_all(self, question_id: str) -> list[GazeSegment] :
+        """
+        questionId 기준 전체 세그먼트 반환 + 버퍼 제거.
+
+        Args:
+            question_id: 버퍼 키
+
+        Returns:
+            list[GazeSegment]: segmentSequence 오름차순 정렬 보장.
+                               버퍼 비어있으면 빈 리스트 반환.
+
+        Note:
+            호출 후 해당 questionId 버퍼 완전 제거.
+            재호출 시 빈 리스트 반환.
+        """
+        ...
+
+    @abstractmethod
+    async def peek(self, question_id: str) -> list[GazeSegment] :
+        """
+        버퍼 상태 확인 (제거 없음).
+
+        Args:
+            question_id: 버퍼 키
+
+        Returns:
+            list[GazeSegment]: 현재 버퍼 내용 (정렬 완료).
+
+        Note:
+            디버깅 / 모니터링 전용.
+            서비스 로직에서 호출 금지.
+        """
+        ...
+
+    @abstractmethod
+    async def clear(self, question_id: str) -> None :
+        """
+        버퍼 명시적 초기화.
+
+        Args:
+            question_id: 제거할 버퍼 키
+
+        Note:
+            파이프라인 FAILED 처리 시 잔여 세그먼트 정리 목적.
+            pop_all() 없이 버퍼를 비워야 할 때 사용.
+        """
+        ...

--- a/app/media/application/port/scoring_config_port.py
+++ b/app/media/application/port/scoring_config_port.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+
+from media.domain import ScoringConfig
+
+
+class ScoringConfigPort(ABC) :
+    """
+    Consul KV 기반 Scoring 정책 조회 추상화 포트.
+
+    포트 추상화 이유:
+      테스트 환경에서 Consul 없이 LocalScoringConfigAdapter로 대체 가능.
+      Consul 외 다른 설정 저장소로 교체 시 service.py 변경 없음.
+    """
+
+    @abstractmethod
+    async def get_config(
+        self,
+        interview_type: str = "default",
+    ) -> ScoringConfig :
+        """
+        Consul KV에서 점수 산출 정책 조회.
+
+        Args:
+            interview_type: Consul KV 경로 분기 키.
+                            MVP-1: "default" 고정.
+                            MVP-2: "tech" | "personality" | "executive"
+
+        Returns:
+            ScoringConfig:
+              정상    → Consul KV 조회값으로 생성된 ScoringConfig
+              장애    → 캐시 또는 ScoringConfig 기본값 (경고 로그)
+
+        Raises:
+            없음. 모든 장애는 내부에서 fallback 처리.
+                  ScoringConfig 기본값(60s, 50/30/20)이 항상 반환됨.
+        """
+        ...

--- a/app/media/application/port/stt_port.py
+++ b/app/media/application/port/stt_port.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+
+from media.domain import STTResult
+
+class STTPort(ABC) :
+    """
+    STT 아웃바운드 포트.
+
+    책임:
+      WAV 파일 → STTResult 변환.
+      OOM fallback 정책은 어댑터 내부에서 처리.
+        large-v3 실패 → medium 1회 재시도.
+        medium도 실패 → STTTranscriptionError 발생.
+
+    구현체: infrastructure/whisper_stt_adapter.py
+    """
+
+    @abstractmethod
+    async def transcribe(
+        self,
+        audio_path: str,
+        tech_stack: list[str],
+    ) -> STTResult :
+        """
+        WAV 파일을 텍스트로 변환.
+
+        Args:
+            audio_path: 로컬 WAV 파일 경로 (/tmp/{jobId}/audio.wav)
+            tech_stack: initial_prompt 구성용 기술 스택
+
+        Returns:
+            STTResult (raw_transcript, word_timestamps,
+            language_probability, stt_model_used)
+
+        Raises:
+            STTTranscriptionError: large-v3 + medium fallback 모두 실패 시.
+            service.py에서 FAILED 처리.
+        """
+        ...

--- a/app/media/application/port/transcript_correction_port.py
+++ b/app/media/application/port/transcript_correction_port.py
@@ -1,0 +1,48 @@
+from abc import ABC, abstractmethod
+
+from media.domain import CorrectionResult
+
+class TranscriptCorrectionPort(ABC):
+    """
+    LLM CoT 통합 교정 아웃바운드 포트.
+
+    책임:
+      raw_transcript → CorrectionResult 변환.
+      CoT 내부 처리 순서 (단일 LLM 호출):
+        Step 1: 음성 유사 오인식 교정 (문맥 기반)
+                예) "데이터네이스" → "데이터베이스"
+        Step 2: Step 1 결과 기반 기술 용어 한영 교정 (Few-shot)
+                예) "레디스" → "Redis"
+
+    Degraded Mode 정책:
+      JSON 파싱 실패 / timeout / API 오류 → 예외 미전파.
+      어댑터 내부에서 degraded=True CorrectionResult 반환.
+      service.py는 FAILED 처리 없이 degraded 플래그만 전파.
+
+    구현체: infrastructure/claude_haiku_adapter.py
+    """
+
+    @abstractmethod
+    async def correct(
+        self,
+        raw_transcript: str,
+        tech_stack: list[str],
+    ) -> CorrectionResult:
+        """
+        음성 오인식 교정 + 기술 용어 교정 통합 수행.
+
+        Args:
+            raw_transcript: S4 Whisper 원본 텍스트
+            tech_stack:     Few-shot 도메인 분류 + 컨텍스트 힌트
+
+        Returns:
+            CorrectionResult:
+              정상    → corrected_transcript + corrections[] + degraded=False
+                        phonetic_corrected: Step 1 중간 결과 포함
+              Degraded → raw_transcript 원본 + corrections=() + degraded=True
+                         phonetic_corrected=None
+
+        Raises:
+            없음. 모든 실패는 어댑터 내부에서 Degraded Mode 처리.
+        """
+        ...

--- a/app/media/application/service.py
+++ b/app/media/application/service.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from media.domain import (
+    # STT BC
+    STTResult,
+    # Correction BC
+    CorrectionResult,
+    # Transcript BC
+    TranscriptState,
+    # Gaze BC
+    GazeResult,
+    # Keyword BC
+    KeywordResult,
+    # Scoring BC
+    ScoringConfig, TimeScore, ReliabilityFactors, ReliabilityScore,
+    # Pipeline BC
+    MediaProcessingResult,
+)
+from media.application.port.stt_port            import STTPort, TranscriptCorrectionPort
+from media.application.port.gaze_buffer_port    import GazeBufferPort
+from media.application.port.scoring_config_port import ScoringConfigPort
+from media.application.service_helper.keyword_extractor  import KeywordExtractor
+from media.application.service_helper.gaze_aggregator    import GazeAggregator
+from core.exceptions import STTTranscriptionError
+
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────
+# 서비스 입력 커맨드 (Inbound DTO 대신 순수 도메인 커맨드)
+# ──────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ProcessMediaCommand:
+    """
+    POST /internal/media/process 수신 데이터를
+    서비스 레이어로 전달하는 커맨드 객체.
+
+    router.py에서 schema → command 변환 후 service 호출.
+    service.py는 schema에 직접 의존하지 않음 (헥사고날 원칙).
+    """
+    job_id:             str
+    interview_id:       str
+    question_id:        str
+    audio_path:         str          # /tmp/{jobId}/audio.wav
+    answer_duration_ms: int
+    tech_stack:         tuple[str, ...]
+    interview_type:     str = "default"  # Consul KV 분기 (MVP-2)
+
+
+# ──────────────────────────────────────────────
+# 메인 서비스
+# ──────────────────────────────────────────────
+
+class MediaService:
+    """
+    Media 파이프라인 오케스트레이터.
+
+    포트 주입:
+      stt_port:         STTPort
+      correction_port:  TranscriptCorrectionPort
+      gaze_buffer:      GazeBufferPort
+      scoring_config:   ScoringConfigPort
+
+    도메인 서비스 주입:
+      keyword_extractor: KeywordExtractor (CPU 기반, 외부 API 없음)
+      gaze_aggregator:   GazeAggregator   (순수 계산, 외부 API 없음)
+    """
+
+    def __init__(
+        self,
+        stt_port:          STTPort,
+        correction_port:   TranscriptCorrectionPort,
+        gaze_buffer:       GazeBufferPort,
+        scoring_config:    ScoringConfigPort,
+        keyword_extractor: KeywordExtractor,
+        gaze_aggregator:   GazeAggregator,
+    ) -> None:
+        self._stt          = stt_port
+        self._correction   = correction_port
+        self._gaze_buffer  = gaze_buffer
+        self._scoring      = scoring_config
+        self._keywords     = keyword_extractor
+        self._gaze_agg     = gaze_aggregator
+
+    # ──────────────────────────────────────────
+    # Public: 파이프라인 진입점
+    # ──────────────────────────────────────────
+
+    async def process(
+        self,
+        command: ProcessMediaCommand,
+    ) -> MediaProcessingResult:
+        """
+        S4~S8 파이프라인 실행 후 MediaProcessingResult 반환.
+
+        STTTranscriptionError 발생 시에만 FAILED.
+        나머지 단계 실패는 Degraded 처리 후 계속 진행.
+
+        Raises:
+            STTTranscriptionError: S4 실패 시.
+                                   router.py에서 FAILED 페이로드 전송.
+        """
+        logger.info(
+            "파이프라인 시작 job_id=%s question_id=%s",
+            command.job_id, command.question_id,
+        )
+
+        # S4: STT
+        stt_result = await self._run_stt(command)
+
+        # S5: LLM CoT 교정
+        correction_result = await self._run_correction(stt_result, command)
+
+        # TranscriptState 조립
+        transcript = self._build_transcript(stt_result, correction_result)
+
+        # S6 + S7: fan-out 병렬 실행
+        import asyncio
+        keyword_result, gaze_result = await asyncio.gather(
+            self._run_keyword_extraction(transcript),
+            self._run_gaze_aggregation(command),
+        )
+
+        # S8: 점수 산출
+        config = await self._scoring.get_config(command.interview_type)
+        time_score, reliability_score = self._run_scoring(
+            stt_result=stt_result,
+            gaze_result=gaze_result,
+            answer_duration_ms=command.answer_duration_ms,
+            config=config,
+        )
+
+        # 최종 집계
+        degraded = (
+            transcript.degraded      # S5 실패
+            or gaze_result.is_empty  # S7 Gaze 미수신
+            or keyword_result.is_empty  # S6 추출 실패
+        )
+
+        result = MediaProcessingResult(
+            job_id=command.job_id,
+            interview_id=command.interview_id,
+            question_id=command.question_id,
+            transcript=transcript,
+            keywords=keyword_result,
+            gaze=gaze_result,
+            time=time_score,
+            reliability=reliability_score,
+            degraded=degraded,
+        )
+
+        logger.info(
+            "파이프라인 완료 job_id=%s degraded=%s",
+            command.job_id, degraded,
+        )
+
+        return result
+
+    async def buffer_gaze_segment(self, segment) -> None:
+        """
+        POST /internal/media/gaze/segment 수신 시 호출.
+        GazeBufferPort에 위임.
+        """
+        await self._gaze_buffer.push(segment)
+
+    # ──────────────────────────────────────────
+    # Private: 단계별 실행 메서드
+    # ──────────────────────────────────────────
+
+    async def _run_stt(
+        self,
+        command: ProcessMediaCommand,
+    ) -> STTResult:
+        """
+        S4: Whisper STT.
+        실패 시 STTTranscriptionError → 파이프라인 FAILED.
+        language_probability < 0.5 → 경고 로그 + 처리 계속.
+        """
+        result = await self._stt.transcribe(
+            audio_path=command.audio_path,
+            tech_stack=list(command.tech_stack),
+        )
+
+        if result.is_low_confidence:
+            logger.warning(
+                "STT 신뢰도 낮음 job_id=%s language_probability=%.3f",
+                command.job_id,
+                result.language_probability,
+            )
+
+        logger.info(
+            "S4 STT 완료 job_id=%s model=%s words=%d",
+            command.job_id,
+            result.stt_model_used.value,
+            len(result.word_timestamps),
+        )
+
+        return result
+
+    async def _run_correction(
+        self,
+        stt_result: STTResult,
+        command: ProcessMediaCommand,
+    ) -> CorrectionResult:
+        """
+        S5: LLM CoT 통합 교정.
+        실패 시 Degraded Mode 자동 강등 (예외 미전파).
+        """
+        result = await self._correction.correct(
+            raw_transcript=stt_result.raw_transcript,
+            tech_stack=list(command.tech_stack),
+        )
+
+        if result.degraded:
+            logger.warning(
+                "S5 LLM 교정 Degraded job_id=%s",
+                command.job_id,
+            )
+        else:
+            logger.info(
+                "S5 LLM 교정 완료 job_id=%s phonetic=%d term=%d",
+                command.job_id,
+                result.phonetic_correction_count,
+                result.term_correction_count,
+            )
+
+        return result
+
+    def _build_transcript(
+        self,
+        stt_result: STTResult,
+        correction_result: CorrectionResult,
+    ) -> TranscriptState:
+        """
+        S4 + S5 결과를 TranscriptState VO로 조립.
+        두 AR의 값을 읽기만 하고 새 불변 객체 생성.
+        """
+        return TranscriptState(
+            raw_transcript=stt_result.raw_transcript,
+            corrected_transcript=correction_result.corrected_transcript,
+            word_timestamps=stt_result.word_timestamps,
+            corrections=correction_result.corrections,
+            language_probability=stt_result.language_probability,
+            stt_model_used=stt_result.stt_model_used,
+            phonetic_corrected=correction_result.phonetic_corrected,
+            degraded=correction_result.degraded,
+        )
+
+    async def _run_keyword_extraction(
+        self,
+        transcript: TranscriptState,
+    ) -> KeywordResult:
+        """
+        S6: 키워드 추출 (CPU, 외부 API 없음).
+        실패 시 빈 tuple 반환, 파이프라인 계속 진행.
+        """
+        try:
+            result = await self._keywords.extract(
+                text=transcript.corrected_transcript,
+            )
+            logger.info(
+                "S6 키워드 추출 완료 candidates=%d",
+                len(result.candidates),
+            )
+            return result
+        except Exception as e:
+            logger.warning("S6 키워드 추출 실패 — 빈 결과 반환: %s", e)
+            return KeywordResult(candidates=())
+
+    async def _run_gaze_aggregation(
+        self,
+        command: ProcessMediaCommand,
+    ) -> GazeResult:
+        """
+        S7: Gaze 집계.
+        버퍼에서 pop_all() 후 GazeAggregator에 위임.
+        세그먼트 0개 → is_empty=True → Degraded 판단.
+        """
+        segments = await self._gaze_buffer.pop_all(command.question_id)
+
+        if not segments:
+            logger.warning(
+                "S7 Gaze 세그먼트 없음 question_id=%s",
+                command.question_id,
+            )
+
+        result = self._gaze_agg.aggregate(
+            segments=segments,
+            answer_duration_ms=command.answer_duration_ms,
+        )
+
+        logger.info(
+            "S7 Gaze 집계 완료 gaze_score=%s coverage=%.3f",
+            result.gaze_score,
+            result.summary.segment_coverage,
+        )
+
+        return result
+
+    def _run_scoring(
+        self,
+        stt_result: STTResult,
+        gaze_result: GazeResult,
+        answer_duration_ms: int,
+        config: ScoringConfig,
+    ) -> tuple[TimeScore, ReliabilityScore]:
+        """
+        S8: 시간 점수 + 신뢰도 점수 산출.
+        Consul KV 정책(ScoringConfig) 기반.
+        도메인 calculate() 직접 호출.
+        """
+        time_score = TimeScore.calculate(
+            answer_duration_ms=answer_duration_ms,
+            config=config,
+        )
+
+        factors = ReliabilityFactors(
+            question_success_rate=1.0,
+            segment_coverage=gaze_result.summary.segment_coverage,
+            avg_word_confidence=stt_result.avg_word_confidence,
+        )
+        reliability_score = ReliabilityScore.calculate(
+            factors=factors,
+            config=config,
+        )
+
+        logger.info(
+            "S8 점수 산출 완료 time=%d reliability=%d grade=%s",
+            time_score.time_score,
+            reliability_score.score,
+            reliability_score.grade.value,
+        )
+
+        return time_score, reliability_score


### PR DESCRIPTION
## 📌 작업 개요
<!--
작업 목적을 요약해 주세요.
예시: 메인 페이지 배너 로딩 속도 개선
-->
- STTPort: faster-whisper 추상화
- TranscriptCorrectionPort: LLM CoT 통합 교정 추상화
  - Degraded Mode 내부 처리, 예외 미전파
- GazeBufferPort: Gaze 세그먼트 큐 추상화
  - MVP-1 InMemoryGazeBuffer → MVP-2 RedisGazeBuffer 교체 전략
  - push/pop_all/peek/clear 인터페이스
- ScoringConfigPort: Consul KV 정책 조회 추상화
  - TTL 60s 캐시, Consul 장애 시 fallback 보장

## 📑 작업 사항 (Checklist)
- [x] Base branch(develop/main)의 최신 내용을 반영(Rebase)했는가?
- [x] **새로운 패키지를 설치했다면 requirements.txt 또는 pyproject.toml에 반영했는가?**
- [x] **비동기 함수(async def) 사용 시 await 키워드가 누락되지 않았는가?**
- [x] **Pytest를 통해 유닛 테스트 및 API 동작 성공을 확인했는가?**
- [x] **Pydantic 모델의 타입 힌트와 명세가 일치하는가?**

## 📸 스크린샷 / 결과물
#### [AS-IS]
<!-- 수정 전 상황이나 문제점을 기술 -->
현재 도메인만 부분만 기술 됨
#### [TO-BE]
<!-- 수정 후의 변화를 적어주세요 -->
도메인을 사용하는 Port를 정의

## 🧪 테스트 결과
- **테스트 환경**:
<!-- 예: Chrome, Postman, iOS -->
-
- **테스트 내용**: 
<!-- 테스트한 시나리오나 결과를 간략히 기술 -->
테스트 내용 없음

## 🔗 관련 이슈 / 문서
<!--
가이드: 이슈를 자동으로 닫으려면 아래 키워드와 이슈 번호를 함께 적으세요.
이슈 자동 종료 가이드:
- closed #이슈번호 (일반적인 이슈 해결)
- fixed #이슈번호 (버그(Bug)를 직접적으로 수정)
- resolved #이슈번호 (기능 구현(Feature)을 완료)
-->
#9 가 PR 통과해야 해당 PR이 가능 
