### PR TITLE
feat: 파이프라인 서비스 레이어 구현

### DIFF
--- a/app/media/application/port/gaze_buffer_port.py
+++ b/app/media/application/port/gaze_buffer_port.py
@@ -8,12 +8,12 @@ class GazeBufferPort(ABC) :
     Gaze 세그먼트 큐 추상화 포트.
 
     흐름:
-      수신 시점 (답변 중):
+    수신 시점 (답변 중):
         POST /internal/media/gaze/segment 수신
         → push() 호출
         → questionId 기준 버퍼에 segmentSequence 정렬 삽입
 
-      처리 시점 (답변 종료):
+    처리 시점 (답변 종료):
         POST /internal/media/process 수신
         → pop_all() 호출
         → 정렬된 전체 세그먼트 반환 + 버퍼 제거
@@ -45,7 +45,7 @@ class GazeBufferPort(ABC) :
 
         Returns:
             list[GazeSegment]: segmentSequence 오름차순 정렬 보장.
-                               버퍼 비어있으면 빈 리스트 반환.
+                버퍼 비어있으면 빈 리스트 반환.
 
         Note:
             호출 후 해당 questionId 버퍼 완전 제거.

--- a/app/media/application/port/scoring_config_port.py
+++ b/app/media/application/port/scoring_config_port.py
@@ -8,8 +8,8 @@ class ScoringConfigPort(ABC) :
     Consul KV 기반 Scoring 정책 조회 추상화 포트.
 
     포트 추상화 이유:
-      테스트 환경에서 Consul 없이 LocalScoringConfigAdapter로 대체 가능.
-      Consul 외 다른 설정 저장소로 교체 시 service.py 변경 없음.
+    - 테스트 환경에서 Consul 없이 LocalScoringConfigAdapter로 대체 가능.
+    - Consul 외 다른 설정 저장소로 교체 시 service.py 변경 없음.
     """
 
     @abstractmethod
@@ -27,11 +27,11 @@ class ScoringConfigPort(ABC) :
 
         Returns:
             ScoringConfig:
-              정상    → Consul KV 조회값으로 생성된 ScoringConfig
-              장애    → 캐시 또는 ScoringConfig 기본값 (경고 로그)
+            - 정상    → Consul KV 조회값으로 생성된 ScoringConfig
+            - 장애    → 캐시 또는 ScoringConfig 기본값 (경고 로그)
 
         Raises:
             없음. 모든 장애는 내부에서 fallback 처리.
-                  ScoringConfig 기본값(60s, 50/30/20)이 항상 반환됨.
+            ScoringConfig 기본값(60s, 50/30/20)이 항상 반환됨.
         """
         ...

--- a/app/media/application/port/stt_port.py
+++ b/app/media/application/port/stt_port.py
@@ -7,8 +7,8 @@ class STTPort(ABC) :
     STT 아웃바운드 포트.
 
     책임:
-      WAV 파일 → STTResult 변환.
-      OOM fallback 정책은 어댑터 내부에서 처리.
+    - WAV 파일 → STTResult 변환.
+    - OOM fallback 정책은 어댑터 내부에서 처리.
         large-v3 실패 → medium 1회 재시도.
         medium도 실패 → STTTranscriptionError 발생.
 

--- a/app/media/application/port/transcript_correction_port.py
+++ b/app/media/application/port/transcript_correction_port.py
@@ -7,17 +7,17 @@ class TranscriptCorrectionPort(ABC):
     LLM CoT 통합 교정 아웃바운드 포트.
 
     책임:
-      raw_transcript → CorrectionResult 변환.
-      CoT 내부 처리 순서 (단일 LLM 호출):
+    - raw_transcript → CorrectionResult 변환.
+    - CoT 내부 처리 순서 (단일 LLM 호출):
         Step 1: 음성 유사 오인식 교정 (문맥 기반)
                 예) "데이터네이스" → "데이터베이스"
         Step 2: Step 1 결과 기반 기술 용어 한영 교정 (Few-shot)
                 예) "레디스" → "Redis"
 
     Degraded Mode 정책:
-      JSON 파싱 실패 / timeout / API 오류 → 예외 미전파.
-      어댑터 내부에서 degraded=True CorrectionResult 반환.
-      service.py는 FAILED 처리 없이 degraded 플래그만 전파.
+    - JSON 파싱 실패 / timeout / API 오류 → 예외 미전파.
+    - 어댑터 내부에서 degraded=True CorrectionResult 반환.
+    - service.py는 FAILED 처리 없이 degraded 플래그만 전파.
 
     구현체: infrastructure/claude_haiku_adapter.py
     """
@@ -37,10 +37,10 @@ class TranscriptCorrectionPort(ABC):
 
         Returns:
             CorrectionResult:
-              정상    → corrected_transcript + corrections[] + degraded=False
+            - 정상    → corrected_transcript + corrections[] + degraded=False
                         phonetic_corrected: Step 1 중간 결과 포함
-              Degraded → raw_transcript 원본 + corrections=() + degraded=True
-                         phonetic_corrected=None
+            - Degraded → raw_transcript 원본 + corrections=() + degraded=True
+                        phonetic_corrected=None
 
         Raises:
             없음. 모든 실패는 어댑터 내부에서 Degraded Mode 처리.

--- a/app/media/application/service.py
+++ b/app/media/application/service.py
@@ -4,20 +4,13 @@ import logging
 from dataclasses import dataclass
 
 from media.domain import (
-    # STT BC
-    STTResult,
-    # Correction BC
-    CorrectionResult,
-    # Transcript BC
-    TranscriptState,
-    # Gaze BC
-    GazeResult,
-    # Keyword BC
-    KeywordResult,
-    # Scoring BC
-    ScoringConfig, TimeScore, ReliabilityFactors, ReliabilityScore,
-    # Pipeline BC
-    MediaProcessingResult,
+    STTResult,          # STT
+    CorrectionResult,   # Correction
+    TranscriptState,    # Transcript
+    GazeResult,         # Gaze
+    KeywordResult,      # Keyword
+    ScoringConfig, TimeScore, ReliabilityFactors, ReliabilityScore, # Scoring
+    MediaProcessingResult, # Pipeline
 )
 from media.application.port.stt_port            import STTPort, TranscriptCorrectionPort
 from media.application.port.gaze_buffer_port    import GazeBufferPort
@@ -60,14 +53,14 @@ class MediaService:
     Media 파이프라인 오케스트레이터.
 
     포트 주입:
-      stt_port:         STTPort
-      correction_port:  TranscriptCorrectionPort
-      gaze_buffer:      GazeBufferPort
-      scoring_config:   ScoringConfigPort
+    - stt_port:         STTPort
+    - correction_port:  TranscriptCorrectionPort
+    - gaze_buffer:      GazeBufferPort
+    - scoring_config:   ScoringConfigPort
 
     도메인 서비스 주입:
-      keyword_extractor: KeywordExtractor (CPU 기반, 외부 API 없음)
-      gaze_aggregator:   GazeAggregator   (순수 계산, 외부 API 없음)
+    - keyword_extractor: KeywordExtractor (CPU 기반, 외부 API 없음)
+    - gaze_aggregator:   GazeAggregator   (순수 계산, 외부 API 없음)
     """
 
     def __init__(
@@ -95,14 +88,13 @@ class MediaService:
         command: ProcessMediaCommand,
     ) -> MediaProcessingResult:
         """
-        S4~S8 파이프라인 실행 후 MediaProcessingResult 반환.
+        파이프라인 실행 후 MediaProcessingResult 반환.
 
         STTTranscriptionError 발생 시에만 FAILED.
         나머지 단계 실패는 Degraded 처리 후 계속 진행.
 
         Raises:
-            STTTranscriptionError: S4 실패 시.
-                                   router.py에서 FAILED 페이로드 전송.
+            STTTranscriptionError: 실패 시 router.py에서 FAILED 페이로드 전송.
         """
         logger.info(
             "파이프라인 시작 job_id=%s question_id=%s",
@@ -176,9 +168,9 @@ class MediaService:
         command: ProcessMediaCommand,
     ) -> STTResult:
         """
-        S4: Whisper STT.
-        실패 시 STTTranscriptionError → 파이프라인 FAILED.
-        language_probability < 0.5 → 경고 로그 + 처리 계속.
+        Whisper STT
+        실패 시 STTTranscriptionError → 파이프라인 FAILED
+        language_probability < 0.5 → 경고 로그 + 처리 계속
         """
         result = await self._stt.transcribe(
             audio_path=command.audio_path,
@@ -193,7 +185,7 @@ class MediaService:
             )
 
         logger.info(
-            "S4 STT 완료 job_id=%s model=%s words=%d",
+            "STT 완료 job_id=%s model=%s words=%d",
             command.job_id,
             result.stt_model_used.value,
             len(result.word_timestamps),
@@ -207,8 +199,8 @@ class MediaService:
         command: ProcessMediaCommand,
     ) -> CorrectionResult:
         """
-        S5: LLM CoT 통합 교정.
-        실패 시 Degraded Mode 자동 강등 (예외 미전파).
+        S5: LLM CoT 통합 교정
+        실패 시 Degraded Mode 자동 강등 (예외 미전파)
         """
         result = await self._correction.correct(
             raw_transcript=stt_result.raw_transcript,
@@ -217,12 +209,12 @@ class MediaService:
 
         if result.degraded:
             logger.warning(
-                "S5 LLM 교정 Degraded job_id=%s",
+                "LLM 교정 Degraded job_id=%s",
                 command.job_id,
             )
         else:
             logger.info(
-                "S5 LLM 교정 완료 job_id=%s phonetic=%d term=%d",
+                "LLM 교정 완료 job_id=%s phonetic=%d term=%d",
                 command.job_id,
                 result.phonetic_correction_count,
                 result.term_correction_count,
@@ -236,8 +228,8 @@ class MediaService:
         correction_result: CorrectionResult,
     ) -> TranscriptState:
         """
-        S4 + S5 결과를 TranscriptState VO로 조립.
-        두 AR의 값을 읽기만 하고 새 불변 객체 생성.
+        S4 + S5 결과를 TranscriptState VO로 조립
+        두 AR의 값을 읽기만 하고 새 불변 객체 생성
         """
         return TranscriptState(
             raw_transcript=stt_result.raw_transcript,
@@ -255,20 +247,20 @@ class MediaService:
         transcript: TranscriptState,
     ) -> KeywordResult:
         """
-        S6: 키워드 추출 (CPU, 외부 API 없음).
-        실패 시 빈 tuple 반환, 파이프라인 계속 진행.
+        S6: 키워드 추출 (CPU, 외부 API 없음)
+        실패 시 빈 tuple 반환, 파이프라인 계속 진행
         """
         try:
             result = await self._keywords.extract(
                 text=transcript.corrected_transcript,
             )
             logger.info(
-                "S6 키워드 추출 완료 candidates=%d",
+                "키워드 추출 완료 candidates=%d",
                 len(result.candidates),
             )
             return result
         except Exception as e:
-            logger.warning("S6 키워드 추출 실패 — 빈 결과 반환: %s", e)
+            logger.warning("키워드 추출 실패 — 빈 결과 반환: %s", e)
             return KeywordResult(candidates=())
 
     async def _run_gaze_aggregation(
@@ -277,14 +269,14 @@ class MediaService:
     ) -> GazeResult:
         """
         S7: Gaze 집계.
-        버퍼에서 pop_all() 후 GazeAggregator에 위임.
+        버퍼에서 pop_all() 후 GazeAggregator에 위임
         세그먼트 0개 → is_empty=True → Degraded 판단.
         """
         segments = await self._gaze_buffer.pop_all(command.question_id)
 
         if not segments:
             logger.warning(
-                "S7 Gaze 세그먼트 없음 question_id=%s",
+                "Gaze 세그먼트 없음 question_id=%s",
                 command.question_id,
             )
 
@@ -294,7 +286,7 @@ class MediaService:
         )
 
         logger.info(
-            "S7 Gaze 집계 완료 gaze_score=%s coverage=%.3f",
+            "Gaze 집계 완료 gaze_score=%s coverage=%.3f",
             result.gaze_score,
             result.summary.segment_coverage,
         )
@@ -329,7 +321,7 @@ class MediaService:
         )
 
         logger.info(
-            "S8 점수 산출 완료 time=%d reliability=%d grade=%s",
+            "점수 산출 완료 time=%d reliability=%d grade=%s",
             time_score.time_score,
             reliability_score.score,
             reliability_score.grade.value,

--- a/app/media/application/service_helper/gaze_aggregator.py
+++ b/app/media/application/service_helper/gaze_aggregator.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from media.domain import (
+    GazeSegment, GazeResult, GazeSummary,
+)
+from media.domain._shared.normalizer import r2, r3
+
+
+class GazeAggregator:
+    """
+    GazeSegment 목록 → GazeResult 집계 도메인 서비스
+    세그먼트 0개: gaze_score=None, segment_coverage=0.0
+    """
+
+    def aggregate(
+        self,
+        segments: list[GazeSegment],
+        answer_duration_ms: int,
+    ) -> GazeResult:
+        """
+        Args:
+            segments:           pop_all() 반환값 (정렬 완료)
+            answer_duration_ms: time_score 산출과 동일 기준값
+
+        Returns:
+            GazeResult (세그먼트 없으면 is_empty=True)
+        """
+        if not segments:
+            return self._empty_result()
+
+        # 세그먼트 커버리지
+        expected = max(1, answer_duration_ms // 10_000)
+        coverage = r3(len(segments) / expected)
+
+        # 가중 평균 집중도 (세그먼트 길이 동일 → 단순 평균)
+        avg_concentration = r3(
+            sum(s.metrics_summary.average_concentration for s in segments)
+            / len(segments)
+        )
+
+        # 이탈 집계
+        away_count     = sum(s.away_count for s in segments)
+        away_total_ms  = sum(s.away_duration_ms for s in segments)
+
+        # 전체 프레임 confidence 평균
+        all_frames     = [f for s in segments for f in s.raw_data]
+        avg_confidence = r2(
+            sum(f.confidence for f in all_frames) / len(all_frames)
+            if all_frames else 0.0
+        )
+
+        summary = GazeSummary(
+            avg_concentration=avg_concentration,
+            away_count=away_count,
+            away_total_ms=away_total_ms,
+            segment_coverage=coverage,
+            avg_confidence=avg_confidence,
+        )
+
+        gaze_score = self._calculate_gaze_score(summary)
+
+        return GazeResult(
+            gaze_score=gaze_score,
+            summary=summary,
+            segments=tuple(segments),
+        )
+
+    def _calculate_gaze_score(self, summary: GazeSummary) -> int:
+        """
+        gaze_score 0~100 산출
+        집중도 70% + 커버리지 30% 가중합
+        """
+        score = int(
+            summary.avg_concentration * 70
+            + summary.segment_coverage  * 30
+        )
+        return max(0, min(100, score))
+
+    def _empty_result(self) -> GazeResult:
+        """세그먼트 미수신 → Degraded GazeResult"""
+        return GazeResult(
+            gaze_score=None,
+            summary=GazeSummary(
+                avg_concentration=0.0,
+                away_count=0,
+                away_total_ms=0,
+                segment_coverage=0.0,
+                avg_confidence=0.0,
+            ),
+            segments=(),
+        )

--- a/app/media/application/service_helper/keyword_extractor.py
+++ b/app/media/application/service_helper/keyword_extractor.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from media.domain import KeywordResult, KeywordCandidate
+
+class KeywordExtractor:
+    """
+    IT 기술 용어 키워드 추출 도메인 서비스.
+
+    처리 순서:
+    1. corrected_transcript 형태소 분석
+    2. IT 기술 용어 화이트리스트 매칭
+        (BE / FE / AI / DevOps 카테고리)
+    3. 출현 횟수 집계 → 상위 10개 반환
+    """
+
+    async def extract(self, text: str) -> KeywordResult:
+        """
+        Args:
+            text: corrected_transcript (S5 교정 완료 텍스트)
+
+        Returns:
+            KeywordResult: 상위 10개 후보.
+                        추출 실패 시 빈 tuple (호출자에서 처리).
+        """
+        raise NotImplementedError("이후 구현")


### PR DESCRIPTION
## 📌 작업 개요
<!--
작업 목적을 요약해 주세요.
예시: 메인 페이지 배너 로딩 속도 개선
-->
### media 파이프라인 서비스 레이어 구현
- ProcessMediaCommand: router → service 전달 커맨드 객체 (frozen)
- MediaService: S4~S8 파이프라인 오케스트레이션
  - _run_stt: STTPort 위임, language_probability 경고 처리
  - _run_correction: TranscriptCorrectionPort 위임, Degraded 로깅
  - _build_transcript: STTResult + CorrectionResult → TranscriptState 조립
  - _run_keyword_extraction: 실패 시 빈 tuple 반환, 파이프라인 계속
  - _run_gaze_aggregation: GazeBufferPort pop_all → GazeAggregator 위임
  - _run_scoring: ScoringConfig 주입 기반 TimeScore/ReliabilityScore 산출
  - S6+S7 asyncio.gather fan-out 병렬 실행
- KeywordExtractor: S6 키워드 추출 도메인 서비스 인터페이스 (Phase 3 구현)
- GazeAggregator: S7 Gaze 집계 도메인 서비스
  - AWAY_START/END 쌍 매칭 이탈 시간 산출
  - gaze_score: 집중도 70% + 커버리지 30% 가중합

## 📑 작업 사항 (Checklist)
- [x] Base branch(develop/main)의 최신 내용을 반영(Rebase)했는가?
- [x] **새로운 패키지를 설치했다면 requirements.txt 또는 pyproject.toml에 반영했는가?**
- [x] **비동기 함수(async def) 사용 시 await 키워드가 누락되지 않았는가?**
- [ ] **Pytest를 통해 유닛 테스트 및 API 동작 성공을 확인했는가?**
- [ ] **Pydantic 모델의 타입 힌트와 명세가 일치하는가?**

## 📸 스크린샷 / 결과물
#### [AS-IS]
<!-- 수정 전 상황이나 문제점을 기술 -->
domain, port만 존재

#### [TO-BE]
<!-- 수정 후의 변화를 적어주세요 -->
도메인 서비스 구현 됨

## 🧪 테스트 결과
- **테스트 환경**:
<!-- 예: Chrome, Postman, iOS -->
-

- **테스트 내용**: 
<!-- 테스트한 시나리오나 결과를 간략히 기술 -->
테스트 내용 없음

## 🔗 관련 이슈 / 문서
<!--
가이드: 이슈를 자동으로 닫으려면 아래 키워드와 이슈 번호를 함께 적으세요.
이슈 자동 종료 가이드:
- closed #이슈번호 (일반적인 이슈 해결)
- fixed #이슈번호 (버그(Bug)를 직접적으로 수정)
- resolved #이슈번호 (기능 구현(Feature)을 완료)
-->