### PR TITLE
feat: 공통 Webhook 전송 컴포넌트 구현 (core/webhook)

### DIFF
--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -1,0 +1,57 @@
+"""
+구조화 로그 설정.
+
+dlq 로거:
+- MVP1: /var/log/dlq/dlq.log 파일 출력.
+- MVP2: Loki 핸들러 추가 (파일 핸들러 유지).
+        dlq_logger.addHandler(LokiHandler(...))
+        코드 변경 없이 핸들러만 추가.
+"""
+
+import logging
+import logging.config
+from pathlib import Path
+
+def setup_logging(log_dir: str = "/var/log/dlq") -> None:
+    Path(log_dir).mkdir(parents=True, exist_ok=True)
+
+    logging.config.dictConfig({
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "json": {
+                # 메시지 자체가 이미 JSON이므로 포맷 최소화
+                "format": "%(message)s",
+            },
+            "standard": {
+                "format": "%(asctime)s %(levelname)s %(name)s %(message)s",
+            },
+        },
+        "handlers": {
+            "console": {
+                "class":     "logging.StreamHandler",
+                "formatter": "standard",
+            },
+            # DLQ 파일 핸들러(MVP1)
+            "dlq_file": {
+                "class":       "logging.handlers.RotatingFileHandler",
+                "filename":    f"{log_dir}/dlq.log",
+                "maxBytes":    10 * 1024 * 1024,  # 10MB
+                "backupCount": 5,
+                "formatter":   "json",
+                "encoding":    "utf-8",
+            },
+        },
+        "loggers": {
+            # DLQ 전용 로거 — MVP2에서 Loki 핸들러 추가
+            "dlq": {
+                "handlers":  ["dlq_file"],
+                "level":     "CRITICAL",
+                "propagate": False,
+            },
+        },
+        "root": {
+            "handlers": ["console"],
+            "level":    "INFO",
+        },
+    })

--- a/app/core/webhook/__init__.py
+++ b/app/core/webhook/__init__.py
@@ -1,0 +1,4 @@
+from .retry_policy  import RetryPolicy
+from .webhook_sender import WebhookSender
+
+__all__ = ["RetryPolicy", "WebhookSender"]

--- a/app/core/webhook/retry_policy.py
+++ b/app/core/webhook/retry_policy.py
@@ -1,0 +1,52 @@
+"""
+Webhook 재시도 정책 Value Object.
+frozen=True: 정책값 불변 보장.
+
+MVP-1 기본값:
+- max_attempts=3, backoff_seconds=2.0
+- → 2s → 4s → 8s 지수 백오프
+
+MVP-2: Consul KV 또는 환경변수로 정책 외부 주입 가능.
+
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """
+    Webhook 전송 재시도 정책 VO.
+
+    max_attempts:    최대 시도 횟수 (초기 시도 포함).
+    backoff_seconds: 지수 백오프 초기값 (초).
+                    1회 실패 후 backoff_seconds
+                    2회 실패 후 backoff_seconds * 2
+                    3회 실패 후 backoff_seconds * 4
+    timeout_seconds: 단건 요청 타임아웃.
+    """
+    max_attempts:    int   = 3
+    backoff_seconds: float = 2.0
+    timeout_seconds: float = 10.0
+
+    def __post_init__(self) -> None:
+        if self.max_attempts < 1:
+            raise ValueError(
+                f"max_attempts는 1 이상이어야 함: {self.max_attempts}"
+            )
+        if self.backoff_seconds <= 0:
+            raise ValueError(
+                f"backoff_seconds는 0 초과여야 함: {self.backoff_seconds}"
+            )
+
+    @property
+    def wait_seconds(self) -> list[float]:
+        """
+        각 재시도 대기 시간 목록.
+        예) max_attempts=3, backoff=2.0
+            → [2.0, 4.0, 8.0]
+        """
+        return [
+            self.backoff_seconds * (2 ** i)
+            for i in range(self.max_attempts)
+        ]

--- a/app/core/webhook/webhook_sender.py
+++ b/app/core/webhook/webhook_sender.py
@@ -1,0 +1,193 @@
+# core/webhook/webhook_sender.py
+"""
+공통 Webhook 전송 컴포넌트.
+
+tenacity 기반 재시도 + 구조화 로그 DLQ.
+
+사용처: webhook으로 spring serverdㅔ 전달하는 부분들
+
+MVP-1: 3회 실패 시 구조화 JSON 로그 파일 출력
+MVP-2: Grafana Loki 수집 (로그 출력 방식만 변경)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    before_sleep_log,
+    RetryError,
+)
+
+from .retry_policy import RetryPolicy
+
+logger         = logging.getLogger(__name__)
+dlq_logger     = logging.getLogger("dlq")  # DLQ 전용 로거 -> MVP-2: Loki 핸들러 교체
+
+
+class WebhookSender:
+    """
+    공통 Webhook 전송 컴포넌트.
+
+    재시도 정책:
+      tenacity 지수 백오프 (기본 2s → 4s → 8s).
+      재시도 대상: 네트워크 오류, 5xx 응답.
+      재시도 제외: 4xx 응답 (클라이언트 오류 — 재시도 무의미).
+
+    DLQ(Dead Letter Queue):
+      MVP-1: dlq_logger → 파일 핸들러 (JSON 구조화 로그).
+      MVP-2: dlq_logger 핸들러를 Loki로 교체.
+             WebhookSender 코드 변경 없음.
+    """
+
+    def __init__(self, policy: RetryPolicy | None = None) -> None:
+        self._policy = policy or RetryPolicy()
+
+    async def send(
+        self,
+        url:     str,
+        payload: dict[str, Any],
+        target:  str,           # 로깅 식별자 (spring_webhook / feedback_event)
+        job_id:  str,
+    ) -> None:
+        """
+        Webhook 전송 진입점
+
+        Args:
+            url:     전송 대상 엔드포인트
+            payload: 전송 페이로드
+            target:  로깅 식별자
+            job_id:  추적용 작업 ID
+
+        Raises:
+            없음. 최종 실패 시 DLQ 로그 기록 후 반환
+        """
+        try:
+            await self._send_with_retry(url, payload, job_id, target)
+
+        except RetryError as e:
+            self._write_dlq_log(
+                job_id=job_id,
+                target=target,
+                url=url,
+                payload=payload,
+                retry_count=self._policy.max_attempts,
+                last_error=str(e.last_attempt.exception()),
+            )
+
+        except Exception as e:
+            # 재시도 대상 외 예외 (4xx 등)
+            logger.error(
+                "Webhook 전송 불가 job_id=%s target=%s error=%s",
+                job_id, target, e,
+            )
+            self._write_dlq_log(
+                job_id=job_id,
+                target=target,
+                url=url,
+                payload=payload,
+                retry_count=0,
+                last_error=str(e),
+            )
+
+    # Private
+    async def _send_with_retry(
+        self,
+        url:     str,
+        payload: dict[str, Any],
+        job_id:  str,
+        target:  str,
+    ) -> None:
+        """
+        tenacity 재시도 래퍼.
+        RetryPolicy 값을 tenacity 데코레이터에 동적 적용.
+        """
+        @retry(
+            retry=retry_if_exception_type(
+                (httpx.TransportError, httpx.TimeoutException, _RetryableError)
+            ),
+            stop=stop_after_attempt(self._policy.max_attempts),
+            wait=wait_exponential(
+                multiplier=self._policy.backoff_seconds,
+                min=self._policy.backoff_seconds,
+            ),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=False,       # RetryError로 래핑
+        )
+        async def _attempt() -> None:
+            async with httpx.AsyncClient(
+                timeout=self._policy.timeout_seconds
+            ) as client:
+                response = await client.post(
+                    url,
+                    json=payload,
+                    headers={"Content-Type": "application/json"},
+                )
+
+                if response.status_code >= 500:
+                    raise _RetryableError(
+                        f"5xx 응답: {response.status_code}"
+                    )
+
+                if response.status_code >= 400:
+                    raise _NonRetryableError(
+                        f"4xx 응답: {response.status_code}"
+                    )
+
+            logger.info(
+                "Webhook 전송 성공 job_id=%s target=%s",
+                job_id, target,
+            )
+
+        await _attempt()
+
+    def _write_dlq_log(
+        self,
+        job_id:      str,
+        target:      str,
+        url:         str,
+        payload:     dict[str, Any],
+        retry_count: int,
+        last_error:  str,
+    ) -> None:
+        """
+        DLQ 구조화 로그 기록.
+
+        MVP-1: dlq_logger → 파일 핸들러 출력.
+        MVP-2: dlq_logger 핸들러 → Loki 교체. 이 메서드 코드 변경 없음.
+
+        grep 복구 예시:
+          grep "webhook_dead_letter" /var/log/dlq/dlq.log
+          grep "job_id" /var/log/dlq/dlq.log | jq .
+        """
+        dlq_logger.critical(
+            json.dumps(
+                {
+                    "event":       "webhook_dead_letter",
+                    "job_id":      job_id,
+                    "target":      target,
+                    "url":         url,
+                    "payload":     payload,
+                    "retry_count": retry_count,
+                    "last_error":  last_error,
+                    "failed_at":   datetime.now(timezone.utc).isoformat(),
+                },
+                ensure_ascii=False,
+            )
+        )
+
+# 내부 예외 (tenacity 재시도 분기용) -> Exception 부분이 공통으로 생기면 이전 예정
+
+class _RetryableError(Exception):
+    """5xx — 재시도 대상."""
+
+class _NonRetryableError(Exception):
+    """4xx — 재시도 제외."""


### PR DESCRIPTION
## 📌 작업 개요
<!--
작업 목적을 요약해 주세요.
예시: 메인 페이지 배너 로딩 속도 개선
-->
### 공통 Webhook 전송 컴포넌트 구현
- 사용 이유: 재시도 정책 통일과 로깅을 용이하게 하기 위함
- RetryPolicy: 재시도 정책 VO (frozen)
  - 기본값: max_attempts=3, backoff=2s (2s→4s→8s)
  - wait_seconds property: 대기 시간 목록 계산
- WebhookSender: tenacity 재시도 + DLQ 구조화 로그
  - 5xx: 재시도 대상 (_RetryableError)
  - 4xx: 재시도 제외 (_NonRetryableError)
  - 최종 실패: dlq_logger CRITICAL JSON 로그 기록
- logging_config.py: dlq 전용 로거 설정
  - MVP-1: RotatingFileHandler (/var/log/dlq/dlq.log)
  - MVP-2: Loki 핸들러 추가만으로 전환 (코드 변경 없음)

## 📑 작업 사항 (Checklist)
- [x] Base branch(develop/main)의 최신 내용을 반영(Rebase)했는가?
- [ ] **새로운 패키지를 설치했다면 requirements.txt 또는 pyproject.toml에 반영했는가?**
- [ ] **비동기 함수(async def) 사용 시 await 키워드가 누락되지 않았는가?**
- [ ] **Pytest를 통해 유닛 테스트 및 API 동작 성공을 확인했는가?**
- [ ] **Pydantic 모델의 타입 힌트와 명세가 일치하는가?**

## 📸 스크린샷 / 결과물
#### [AS-IS]
<!-- 수정 전 상황이나 문제점을 기술 -->
공통 전송 컴포넌트 미존재

#### [TO-BE]
<!-- 수정 후의 변화를 적어주세요 -->
webhook 공통 전송 컴포넌트 구현

## 🧪 테스트 결과
- **테스트 환경**:
<!-- 예: Chrome, Postman, iOS -->


- **테스트 내용**: 
<!-- 테스트한 시나리오나 결과를 간략히 기술 -->
테스트 내용 없음

## 🔗 관련 이슈 / 문서
<!--
가이드: 이슈를 자동으로 닫으려면 아래 키워드와 이슈 번호를 함께 적으세요.
이슈 자동 종료 가이드:
- closed #이슈번호 (일반적인 이슈 해결)
- fixed #이슈번호 (버그(Bug)를 직접적으로 수정)
- resolved #이슈번호 (기능 구현(Feature)을 완료)
-->- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 