### PR TITLE
feat: connect s3

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     # extra="ignore"를 추가하여 정의되지 않은 변수(openai_api_key 등)로 인한 에러를 방지합니다.
     model_config = SettingsConfigDict(
         env_file=".env",
-        extra="ignore" 
+        #extra="ignore" 
     )
 
 settings = Settings()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,6 +6,10 @@ class Settings(BaseSettings):
     aws_region: str
     s3_bucket_name: str
 
-    model_config = SettingsConfigDict(env_file=".env")
+    # extra="ignore"를 추가하여 정의되지 않은 변수(openai_api_key 등)로 인한 에러를 방지합니다.
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="ignore" 
+    )
 
 settings = Settings()

--- a/app/question/infrastructure/di.py
+++ b/app/question/infrastructure/di.py
@@ -11,14 +11,11 @@ from app.question.infrastructure.llm_structuring_adapter import LLMStructuringAd
 from app.question.infrastructure.llm_question_gen_adapter import LLMQuestionGenAdapter
 from app.question.infrastructure.structuring_prompt_provider import StructuringPromptProvider
 from app.question.infrastructure.question_gen_prompt_provider import QuestionGenPromptProvider
-
+from app.question.infrastructure.s3_download_adapter import S3DownloadAdapter
 
 def get_s3_download_port() -> S3DownloadPort:
-    return LocalFileAdapter()
-
-    # ↓ AWS 키 수령 후 교체
-    # from app.question.infrastructure.s3_download_adapter import S3DownloadAdapter
-    # return S3DownloadAdapter()
+    #return LocalFileAdapter()
+    return S3DownloadAdapter(timeout=60.0) # PDF가 클 수 있으므로 60초 넉넉히 설정
 
 
 def get_pdf_extract_port() -> PdfExtractPort:

--- a/app/question/infrastructure/s3_download_adapter.py
+++ b/app/question/infrastructure/s3_download_adapter.py
@@ -1,23 +1,50 @@
-import aioboto3
+import httpx
+import logging
 from app.question.application.port.s3_download_port import S3DownloadPort
 from app.core.config import settings
 
+logger = logging.getLogger(__name__)
+
 class S3DownloadAdapter(S3DownloadPort):
+    def __init__(self, timeout: float = 30.0):
+        self.timeout = timeout
 
     async def download(self, url: str) -> bytes:
-        session = aioboto3.Session()
-        async with session.client(
-            "s3",
-            region_name=settings.aws_region,
-            aws_access_key_id=settings.aws_access_key_id,
-            aws_secret_access_key=settings.aws_secret_access_key,
-        ) as client:
-            bucket, key = self._parse_url(url)
-            response = await client.get_object(Bucket=bucket, Key=key)
-            return await response["Body"].read()
+        """
+        Spring으로부터 받은 Presigned URL을 통해 파일을 다운로드합니다.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                logger.info(f"S3 파일 다운로드 시작: {url[:50]}...")
+                
+                response = await client.get(url)
+                
+                # HTTP 에러(403 Forbidden, 404 Not Found 등) 발생 시 예외 발생
+                response.raise_for_status()
+                
+                file_data = response.content
+                logger.info(f"다운로드 완료: {len(file_data)} bytes 수신")
+                
+                return file_data
 
-    def _parse_url(self, url: str) -> tuple[str, str]:
-        # s3://bucket-name/path/to/file.pdf
-        path = url.replace("s3://", "")
-        bucket, key = path.split("/", 1)
-        return bucket, key
+        except httpx.HTTPStatusError as e:
+            # 403(만료/권한), 404(파일없음) 등 서버 응답 에러 처리
+            logger.error(f"S3 다운로드 실패 (상태 코드: {e.response.status_code}): {e}")
+            if e.response.status_code == 403:
+                raise ValueError("S3 URL이 만료되었거나 접근 권한이 없습니다.") from e
+            raise Exception(f"S3 서버 에러 발생: {e.response.status_code}") from e
+
+        except httpx.RequestError as e:
+            # 네트워크 단절, 타임아웃 등 요청 자체 실패 처리
+            logger.error(f"S3 연결 중 네트워크 에러 발생: {e}")
+            raise Exception("S3 서버에 연결할 수 없습니다. 네트워크 상태를 확인하세요.") from e
+
+        except Exception as e:
+            logger.error(f"알 수 없는 오류 발생: {e}")
+            raise e
+
+    # def _parse_url(self, url: str) -> tuple[str, str]:
+    #     # s3://bucket-name/path/to/file.pdf
+    #     path = url.replace("s3://", "")
+    #     bucket, key = path.split("/", 1)
+    #     return bucket, key

--- a/callback_receiver.py
+++ b/callback_receiver.py
@@ -1,0 +1,20 @@
+# callback_receiver.py
+from fastapi import FastAPI, Request
+import uvicorn
+
+app = FastAPI()
+
+@app.post("/internal/v1/questions/callback")
+async def receive_question_callback(request: Request):
+    body = await request.json()
+    print("🟢 WEBHOOK 수신 성공!")
+    print("  📋 Payload:", body)
+    print("  🆔 intvId:", body.get("intvId"))
+    print("  ✅ Status:", body.get("status"))
+    print("  ❓ Questions:", body.get("questions", []))
+    print("  ❌ Error:", body.get("errorMessage"))
+    print("-" * 50)
+    return {"status": "received"}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=9000)

--- a/tests.md
+++ b/tests.md
@@ -8,6 +8,19 @@
   "portfolio_url": null,
   "self_introduction_url": null,
   "job_role": "백엔드 개발자"
+
+
+
+
+
+
+}
+
+{
+  "resume_url": "https://gamyeon-s3-bucket.s3.ap-northeast-2.amazonaws.com/resume.pdf",
+  "portfolio_url": null,
+  "self_introduction_url": null,
+  "job_role": "백엔드 개발자"
 }
 ```
 # feedback - test


### PR DESCRIPTION

## 📌 작업 개요

질문 도메인 내 S3 Presigned URL 다운로드 기능 구현 및 인프라 레이어 연결

## 📑 작업 사항 (Checklist)

* [x] Base branch(develop/main)의 최신 내용을 반영(Rebase)했는가?
* [x] **새로운 패키지를 설치했다면 requirements.txt 또는 pyproject.toml에 반영했는가?** (`httpx` 추가)
* [x] **비동기 함수(async def) 사용 시 await 키워드가 누락되지 않았는가?**
* [x] **Pytest를 통해 유닛 테스트 및 API 동작 성공을 확인했는가?**
* [x] **Pydantic 모델의 타입 힌트와 명세가 일치하는가?**

## 📸 스크린샷 / 결과물

(0313 오전 첨부 예정)

#### [AS-IS]

* `S3DownloadPort`의 구현체로 `LocalFileAdapter`를 사용하여 로컬에 저장된 테스트용 PDF 파일로만 질문 생성 로직을 검증함.
* 외부(Spring 서버 등)로부터 전달받은 S3 URL을 처리할 수 있는 인프라 레이어 부재.

#### [TO-BE]

* **`S3DownloadAdapter` 수정**: `httpx` 라이브러리를 사용하여 Presigned URL로부터 비동기 방식으로 파일을 다운로드하는 어댑터 구현.
* **예외 처리 강화**: 403(권한/만료), 404(파일 부재) 등 HTTP 상태 코드별 에러 핸들링 로직 추가.
* **의존성 주입(DI) 연결**: `di.py` 설정을 통해 실제 런타임에서 `S3DownloadAdapter`가 주입되도록 변경.
* test) 설정 최적화✓**: Pydantic `Settings` 클래스에 `extra="ignore"` 설정을 추가하여 `.env` 내 미정의 변수로 인한 초기화 에러 해결.
app\core\config.py 임시수정 (수정사항은 커밋안했습니다)


### 테스트 관련 
✓
test) 설정 최적화: Pydantic `Settings` 클래스에 `extra="ignore"` 설정을 추가하여 `.env` 내 미정의 변수로 인한 초기화 에러 해결.
app\core\config.py 임시수정 (수정사항은 커밋안했습니다)

에러: Extra inputs are not permitted
S3DownloadAdapter를 추가하면서 from app.core.config import settings를 불러올 때, Settings 객체가 초기화되면서 에러가 터졌습니다. 
app.core.config.Settings 클래스에 openai_api_key와 consul_host라는 필드가 정의되어 있지 않거나,
Pydantic 설정에 extra = "forbid" 옵션이 켜져 있는데, 환경 변수(.env 등)에는 해당 값들이 들어 있어서 발생했습니다. 

해결방법은, 위 에러 메시지에 나온 openai_api_key와 consul_host를 필드로 추가하거나 extra="ignore" 설정을 넣는 방법이었습니다.
consul 작업은 추후에 이뤄질 예정이라, main.py ) consul부분 임의로 주석처리한것처러마, 일단 임의로 extra="ignore를 넣어 테스트 진행했습니다.  

## 🧪 테스트 결과

* **테스트 환경**: Python 3.12, Windows 11, Postman, AWS S3(ap-northeast-2)
* **테스트 내용**:
1. S3 버킷에 테스트 PDF(`resume.pdf`) 업로드 후 퍼블릭/프라이빗 접근 테스트 완료.
2. 생성된 Presigned URL을 어댑터에 전달 시 `bytes` 데이터를 정상적으로 수신함을 확인.
3. 수신된 `bytes` 데이터가 `PdfExtractPort`를 거쳐 텍스트로 정상 변환되는 End-to-End 흐름 검증.
4. 잘못되거나 만료된 URL 입력 시 `ValueError` 및 로그 기록 정상 동작 확인.
테스트 한후 s3 버킷 비공개 처리하였습니다. 

## 🔗 관련 이슈 / 문서

* resolved #1 
