### PR TITLE
feat: add json camelCase check logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ uv run uvicorn app.main:app --reload
 
 ***
 
-**③ `/api/ai/question/generate` 클릭 → `Try it out` 클릭**
+**③ `/internal/question/generate` 클릭 → `Try it out` 클릭**
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ uv run uvicorn app.main:app --reload
 
 ***
 
-**③ `/internal/question/generate` 클릭 → `Try it out` 클릭**
+**③ `/internal/questions/generate` 클릭 → `Try it out` 클릭**
 
 ***
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,15 +1,34 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
-    aws_access_key_id: str
-    aws_secret_access_key: str
-    aws_region: str
-    s3_bucket_name: str
-
-    # extra="ignore"를 추가하여 정의되지 않은 변수(openai_api_key 등)로 인한 에러를 방지합니다.
     model_config = SettingsConfigDict(
-        env_file=".env",
-        extra="ignore" 
-    )
+        env_file=".env", 
+        env_file_encoding="utf-8",
+        extra="ignore" )
+
+    # ── AWS / S3 ──────────────────────────────────────────────────
+    AWS_ACCESS_KEY_ID:     str
+    AWS_SECRET_ACCESS_KEY: str
+    AWS_REGION:            str = "ap-northeast-2"
+    S3_BUCKET:             str          # 영상 저장 버킷 이름
+
+    # ── Whisper STT ───────────────────────────────────────────────
+    WHISPER_DEVICE:       str = "cuda"  # "cpu" | "cuda"
+    WHISPER_COMPUTE_TYPE: str = "int8"  # "int8" | "float16" | "float32"
+
+    # ── Claude (LLM 교정) ─────────────────────────────────────────
+    ANTHROPIC_API_KEY:  str
+    CLAUDE_HAIKU_MODEL: str   = "claude-haiku-4-5-20251001"
+    LLM_TIMEOUT_SECONDS: float = 15.0
+
+    # ── Consul (점수 정책) ────────────────────────────────────────
+    CONSUL_URL:   str = "http://consul:8500"
+    CONSUL_TOKEN: str = ""               # ACL 미사용 시 빈 문자열
+
+    # ── Spring Boot 웹훅 ──────────────────────────────────────────
+    SPRING_WEBHOOK_URL: str
+    FEEDBACK_SPRING_WEBHOOK_URL: str
+    
+    OPENAI_API_KEY:  str
 
 settings = Settings()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     # extra="ignore"를 추가하여 정의되지 않은 변수(openai_api_key 등)로 인한 에러를 방지합니다.
     model_config = SettingsConfigDict(
         env_file=".env",
-        #extra="ignore" 
+        extra="ignore" 
     )
 
 settings = Settings()

--- a/app/feedback/router.py
+++ b/app/feedback/router.py
@@ -5,7 +5,7 @@ from app.feedback.infrastructure.di import get_feedback_service
 from app.feedback.schema.request import FeedbackRequest
 from app.feedback.schema.response import FeedbackResponse
 
-router = APIRouter(prefix="/internal/v1/feedback", tags=["feedback"])
+router = APIRouter(prefix="/internal/v1/feedbacks", tags=["feedback"])
 
 
 @router.post("/generate", response_model=ApiResponse[FeedbackResponse])

--- a/app/feedback/schema/request.py
+++ b/app/feedback/schema/request.py
@@ -3,12 +3,22 @@ from typing import Optional
 
 
 class KeywordCandidate(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+    )
+    
     term:     str
     count:    int
     category: str
 
 
 class FeedbackRequest(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+    )
+    
     intv_question_id:     int
     question_text:        str
     corrected_transcript: str

--- a/app/feedback/schema/request.py
+++ b/app/feedback/schema/request.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
+from pydantic.alias_generators import to_camel
 from typing import Optional
 
 
@@ -15,7 +16,7 @@ class KeywordCandidate(BaseModel):
 
 class FeedbackRequest(BaseModel):
     model_config = ConfigDict(
-        alias_generator=to_camel,
+        alias_generator= to_camel,
         populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
     )
     

--- a/app/feedback/schema/response.py
+++ b/app/feedback/schema/response.py
@@ -3,6 +3,12 @@ from typing import Optional
 
 
 class FeedbackResponse(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True, # 💡 핵심: 출력할 때 무조건 alias(camelCase)로 변환해라!
+    )
+    
     intv_question_id:          int
     status:                    str
     logic_score:               Optional[int] = None

--- a/app/feedback/schema/response.py
+++ b/app/feedback/schema/response.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 from typing import Optional
 
 
@@ -6,7 +7,7 @@ class FeedbackResponse(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True,
-        serialize_by_alias=True, # 💡 핵심: 출력할 때 무조건 alias(camelCase)로 변환해라!
+        serialize_by_alias=True
     )
     
     intv_question_id:          int

--- a/app/main.py
+++ b/app/main.py
@@ -1,94 +1,55 @@
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
-
-from contextlib import asynccontextmanager
-from app.core import ConsulHelper
 from dotenv import load_dotenv
+
 from app.report.router import router as report_router
-
 from app.question.router import router as question_router
-import consul, os, uuid
-
-from app.core.schema import ApiResponse
 from app.feedback.router import router as feedback_router
+from app.core.schema import ApiResponse
+
+import os
 
 load_dotenv()
-
-# Configuration about consul client
-consul_host = os.getenv("CONSUL_HOST", "localhost")
-c = consul.Consul(host = consul_host, port = 8500)
-
-@asynccontextmanager
-async def lifespan(app: FastAPI) :
-    consul_helper = ConsulHelper(host="consul")
-    config = consul_helper.get_config("config/agent/settings")
-
-    SERVICE_ID = config.get("SERVICE_ID", "DEFAULT-SERVER")
-    EXTERNAL_HOST_IP = config.get("EXTERNAL_HOST_IP", "127.0.0.1")
-    EC2_PUBLIC_IP = config.get("EC2_PUBLIC_IP", "0.0.0.0")
-
-    # UUID를 사용하여 매번 다른 ID 생성
-    unique_id = f"{SERVICE_ID}:{uuid.uuid4()}" 
-
-    c.agent.service.register(
-        name = SERVICE_ID,
-        service_id = unique_id,
-        address = EXTERNAL_HOST_IP,
-        port = 8000,
-        check = consul.Check.http(f"http://{EC2_PUBLIC_IP}:8000/health", interval = "10s")
-    )
-    print("Consul 등록 완료")
-
-    yield # 서버 실행
-
-    c.agent.service.deregister(SERVICE_ID)
-    print("Consul 등록 해제")
 
 app = FastAPI(
     title="Interview AI Server",
     description="AI Interview Simulator - AI Features",
     version="0.1.0",
-    lifespan = lifespan
 )
 
+# ── 라우터 등록 ──────────────────────────────────────────────────
+app.include_router(question_router, prefix="/api/ai")
+app.include_router(feedback_router)
+app.include_router(report_router)
 
 # ── 헬스체크 ─────────────────────────────────────────────────────
-app.include_router(question_router, prefix="/api/ai")
-
 @app.get("/health")
 def health_check():
     return {"status": "ok", "message": "AI server is running"}
 
-
 # ── 전역 예외 핸들러 ─────────────────────────────────────────────
-
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     return JSONResponse(
         status_code=422,
         content=ApiResponse(
-            success = False,
-            code    = "CMMN-V001",
-            message = "입력값 유효성 검사에 실패했습니다.",
-            data    = None,
+            success=False,
+            code="CMMN-V001",
+            message="입력값 유효성 검사에 실패했습니다.",
+            data=None,
         ).model_dump(),
     )
-
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     return JSONResponse(
         status_code=500,
         content=ApiResponse(
-            success = False,
-            code    = "CMMN-I001",
-            message = "서버 내부 오류가 발생했습니다.",
-            data    = None,
+            success=False,
+            code="CMMN-I001",
+            message="서버 내부 오류가 발생했습니다.",
+            data=None,
         ).model_dump(),
     )
-
-
-# ── 라우터 등록 ──────────────────────────────────────────────────
-app.include_router(feedback_router)
 

--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,7 @@ app = FastAPI(
 )
 
 # ── 라우터 등록 ──────────────────────────────────────────────────
-app.include_router(question_router, prefix="/api/ai")
+app.include_router(question_router)
 app.include_router(feedback_router)
 app.include_router(report_router)
 

--- a/app/main.py
+++ b/app/main.py
@@ -54,7 +54,7 @@ app = FastAPI(
 
 
 # ── 헬스체크 ─────────────────────────────────────────────────────
-app.include_router(question_router, prefix="/api/ai")
+
 
 @app.get("/health")
 def health_check():
@@ -91,3 +91,5 @@ async def global_exception_handler(request: Request, exc: Exception):
 
 # ── 라우터 등록 ──────────────────────────────────────────────────
 app.include_router(feedback_router)
+app.include_router(question_router)
+app.include_router(report_router)

--- a/app/main.py
+++ b/app/main.py
@@ -1,55 +1,93 @@
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
+
+from contextlib import asynccontextmanager
+from app.core import ConsulHelper
 from dotenv import load_dotenv
-
 from app.report.router import router as report_router
-from app.question.router import router as question_router
-from app.feedback.router import router as feedback_router
-from app.core.schema import ApiResponse
 
-import os
+from app.question.router import router as question_router
+import consul, os, uuid
+
+from app.core.schema import ApiResponse
+from app.feedback.router import router as feedback_router
 
 load_dotenv()
+
+# Configuration about consul client
+consul_host = os.getenv("CONSUL_HOST", "localhost")
+c = consul.Consul(host = consul_host, port = 8500)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) :
+    consul_helper = ConsulHelper(host="consul")
+    config = consul_helper.get_config("config/agent/settings")
+
+    SERVICE_ID = config.get("SERVICE_ID", "DEFAULT-SERVER")
+    EXTERNAL_HOST_IP = config.get("EXTERNAL_HOST_IP", "127.0.0.1")
+    EC2_PUBLIC_IP = config.get("EC2_PUBLIC_IP", "0.0.0.0")
+
+    # UUID를 사용하여 매번 다른 ID 생성
+    unique_id = f"{SERVICE_ID}:{uuid.uuid4()}" 
+
+    c.agent.service.register(
+        name = SERVICE_ID,
+        service_id = unique_id,
+        address = EXTERNAL_HOST_IP,
+        port = 8000,
+        check = consul.Check.http(f"http://{EC2_PUBLIC_IP}:8000/health", interval = "10s")
+    )
+    print("Consul 등록 완료")
+
+    yield # 서버 실행
+
+    c.agent.service.deregister(SERVICE_ID)
+    print("Consul 등록 해제")
 
 app = FastAPI(
     title="Interview AI Server",
     description="AI Interview Simulator - AI Features",
     version="0.1.0",
+    lifespan = lifespan
 )
 
-# ── 라우터 등록 ──────────────────────────────────────────────────
-app.include_router(question_router)
-app.include_router(feedback_router)
-app.include_router(report_router)
 
 # ── 헬스체크 ─────────────────────────────────────────────────────
+app.include_router(question_router, prefix="/api/ai")
+
 @app.get("/health")
 def health_check():
     return {"status": "ok", "message": "AI server is running"}
 
+
 # ── 전역 예외 핸들러 ─────────────────────────────────────────────
+
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     return JSONResponse(
         status_code=422,
         content=ApiResponse(
-            success=False,
-            code="CMMN-V001",
-            message="입력값 유효성 검사에 실패했습니다.",
-            data=None,
+            success = False,
+            code    = "CMMN-V001",
+            message = "입력값 유효성 검사에 실패했습니다.",
+            data    = None,
         ).model_dump(),
     )
+
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     return JSONResponse(
         status_code=500,
         content=ApiResponse(
-            success=False,
-            code="CMMN-I001",
-            message="서버 내부 오류가 발생했습니다.",
-            data=None,
+            success = False,
+            code    = "CMMN-I001",
+            message = "서버 내부 오류가 발생했습니다.",
+            data    = None,
         ).model_dump(),
     )
 
+
+# ── 라우터 등록 ──────────────────────────────────────────────────
+app.include_router(feedback_router)

--- a/app/question/router.py
+++ b/app/question/router.py
@@ -9,7 +9,7 @@ from app.question.infrastructure.di import (
 )
 from app.question.application.service import QuestionService
 
-router = APIRouter(prefix="/internal/v1/question", tags=["question"])
+router = APIRouter(prefix="/internal/v1/questions", tags=["question"])
 
 @router.post("/generate", response_model=QuestionGenerateResponse)
 async def generate_question(request: QuestionGenerateRequest):

--- a/app/question/schema/request.py
+++ b/app/question/schema/request.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
 
 class QuestionGenerateRequest(BaseModel):
     

--- a/app/question/schema/request.py
+++ b/app/question/schema/request.py
@@ -1,6 +1,12 @@
 from pydantic import BaseModel
 
 class QuestionGenerateRequest(BaseModel):
+    
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+    )
+    
     resume_url: str
     portfolio_url: str | None = None
     self_introduction_url: str | None = None

--- a/app/question/schema/response.py
+++ b/app/question/schema/response.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 class QuestionGenerateResponse(BaseModel):
     model_config = ConfigDict(

--- a/app/question/schema/response.py
+++ b/app/question/schema/response.py
@@ -1,4 +1,10 @@
 from pydantic import BaseModel
 
 class QuestionGenerateResponse(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True, # 💡 핵심: 출력할 때 무조건 alias(camelCase)로 변환해라!
+    )
+    
     questions: list[str]

--- a/app/report/application/service.py
+++ b/app/report/application/service.py
@@ -47,6 +47,7 @@ class ReportService:
             QuestionSummary(
                 intv_question_id=s["intv_question_id"],
                 question=s["question"],
+                index=s["index"],
                 answer_summary=s["answer_summary"],
                 keywords=s["keywords"],
                 feedback=QuestionFeedbackDetail(

--- a/app/report/infrastructure/static_score_adapter.py
+++ b/app/report/infrastructure/static_score_adapter.py
@@ -81,6 +81,7 @@ class StaticScoreAdapter:
         return [
             {
                 "intv_question_id": f.intv_question_id,
+                "index": f.index,
                 "question": f.question,
                 "answer_summary": f.answer_summary,
                 "keywords": f.feedback_badges,

--- a/app/report/router.py
+++ b/app/report/router.py
@@ -9,8 +9,8 @@ from app.report.schema.response import ReportResponse
 
 
 # convention: /[prefix]/[version]/[domain]/[action]
-# → POST /internal/v1/report/generate
-router = APIRouter(prefix="/internal/v1/report", tags=["report"])
+# → POST /internal/v1/reports/generate
+router = APIRouter(prefix="/internal/v1/reports", tags=["report"])
 
 
 @router.post("/generate")

--- a/app/report/schema/request.py
+++ b/app/report/schema/request.py
@@ -1,7 +1,7 @@
 from enum import Enum
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, model_validator,ConfigDict
 from typing import Optional
-
+from pydantic.alias_generators import to_camel
 
 class FeedbackStatus(str, Enum):
     model_config = ConfigDict(

--- a/app/report/schema/request.py
+++ b/app/report/schema/request.py
@@ -4,12 +4,23 @@ from typing import Optional
 
 
 class FeedbackStatus(str, Enum):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+    )   
+    
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
 
 
 class FeedbackItem(BaseModel):
-    intv_question_id: int 
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+    )
+        
+    intv_question_id: int
+    index: int 
     question: str
     status: FeedbackStatus
     logic_score: int
@@ -26,11 +37,19 @@ class FeedbackItem(BaseModel):
 
 
 class InterviewMeta(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+    )
     job_category: Optional[str] = None
     answered_count: int
 
 
 class ReportRequest(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+    )
     interview_id: int
     meta: InterviewMeta
     feedbacks: list[FeedbackItem]

--- a/app/report/schema/response.py
+++ b/app/report/schema/response.py
@@ -1,12 +1,13 @@
-from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 class CompetencyScores(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True,
-        serialize_by_alias=True, # 💡 핵심: 출력할 때 무조건 alias(camelCase)로 변환해라!
+        serialize_by_alias=True, # 
     )
     
     logic: int

--- a/app/report/schema/response.py
+++ b/app/report/schema/response.py
@@ -3,6 +3,12 @@ from typing import Optional
 from datetime import datetime
 
 class CompetencyScores(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True, # 💡 핵심: 출력할 때 무조건 alias(camelCase)로 변환해라!
+    )
+    
     logic: int
     answer_composition: int
     gaze: int
@@ -10,11 +16,21 @@ class CompetencyScores(BaseModel):
     keyword: int
 
 class QuestionFeedbackDetail(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True, #  핵심: 출력할 때 무조건 alias(camelCase)로 변환해라!
+    )
     characteristic: str
     strength: str
     improvement: str
-
+    
 class QuestionSummary(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True, 
+    )
     index: int
     question: str
     answer_summary: str
@@ -22,6 +38,12 @@ class QuestionSummary(BaseModel):
     feedback: QuestionFeedbackDetail
 
 class ReportResponse(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True, 
+    )
+    
     interview_id: int
     job_category: Optional[str] = None
     answered_count: int

--- a/tests.md
+++ b/tests.md
@@ -8,12 +8,6 @@
   "portfolio_url": null,
   "self_introduction_url": null,
   "job_role": "백엔드 개발자"
-
-
-
-
-
-
 }
 
 {

--- a/uv.lock
+++ b/uv.lock
@@ -223,25 +223,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.84.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -337,6 +318,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
 
 [[package]]
@@ -558,15 +548,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -952,7 +933,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aioboto3" },
-    { name = "anthropic" },
+    { name = "blinker" },
     { name = "fastapi", extra = ["standard"] },
     { name = "faster-whisper" },
     { name = "langchain" },
@@ -976,7 +957,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aioboto3", specifier = ">=15.5.0" },
-    { name = "anthropic", specifier = ">=0.84.0" },
+    { name = "blinker", specifier = ">=1.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.133.1" },
     { name = "faster-whisper", specifier = ">=1.2.1" },
     { name = "langchain", specifier = ">=1.2.10" },


### PR DESCRIPTION
## camelCase로 통일
형식이 API 명세상 섞여있던 것을, 
json 응답 camel case로 공통 입/출력되도록 수정했습니다. 
camelCase로 통일했습니다. 

## main.py
라우터 등록했습니다 
잘못된 prefix 수정했습니다. 

## 리포트 상세조회관련
question_order, question-index 부분 부재 채웠습니다. 

#config.py
전달받은대로 일단 내용 반영했으며,
제가 맡은 기능의 경우, 추가이상의 값은 활용안하도록 extra = "ignore" 적었습니다. 
우선 제 로컬 .env에는 활용안하는 값들은 dummy 내용 넣었습니다. 

