### PR TITLE
Fix/feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ app = FastAPI(
 )
 
 # ── 라우터 등록 ──────────────────────────────────────────────────
-app.include_router(question_router, prefix="/api/ai")
+app.include_router(question_router)
 app.include_router(feedback_router)
 app.include_router(report_router)
 

--- a/app/feedback/application/port/callback_port.py
+++ b/app/feedback/application/port/callback_port.py
@@ -1,0 +1,8 @@
+# feedback/application/port/callback_port.py
+from abc import ABC, abstractmethod
+from app.feedback.schema.response import FeedbackResponse
+
+class FeedbackCallbackPort(ABC):
+
+    @abstractmethod
+    async def send(self, url: str, payload: FeedbackResponse) -> None: ...

--- a/app/feedback/application/service.py
+++ b/app/feedback/application/service.py
@@ -1,21 +1,55 @@
+from app.core.config import settings
 from app.feedback.application.port.feedback_port import FeedbackPort
+from app.feedback.application.port.callback_port import FeedbackCallbackPort
 from app.feedback.domain.feedback_model import QuestionFeedback
-from app.feedback.schema.request import FeedbackRequest
+from app.feedback.schema.request import FeedbackRequest, FeedbackEventRequest
 from app.feedback.schema.response import FeedbackResponse
 
 
 class FeedbackService:
 
-    def __init__(self, feedback_port: FeedbackPort) -> None:
+    def __init__(self, feedback_port: FeedbackPort, callback: FeedbackCallbackPort) -> None:
         self._port = feedback_port
+        self._callback = callback
 
-    async def generate_feedback(self, request: FeedbackRequest) -> FeedbackResponse:
-        result: QuestionFeedback = await self._port.generate_feedback(request)
-        return self._to_response(result)
+    async def run(self, event: FeedbackEventRequest) -> None:
+        try:
+            request = self._to_request(event)          # ← 변환
+            result: QuestionFeedback = await self._port.generate_feedback(request)
+            payload = self._to_response(event, result)
+        except Exception as e:
+            payload = FeedbackResponse(
+                intv_id          = event.intv_id,
+                intv_question_id = event.question_id,
+                status           = "FAILED",
+                error_message    = str(e),
+            )
 
+        await self._callback.send(
+            url=settings.FEEDBACK_SPRING_WEBHOOK_URL,
+            payload=payload,
+        )
+
+    # ── FeedbackEventRequest → FeedbackRequest (어댑터 입력) ────
     @staticmethod
-    def _to_response(domain: QuestionFeedback) -> FeedbackResponse:
+    def _to_request(event: FeedbackEventRequest) -> FeedbackRequest:
+        return FeedbackRequest(
+            intv_question_id     = event.question_id,
+            question_content        = event.question_content,       # ← 아래 확인
+            corrected_transcript = event.transcript.corrected_transcript,
+            degraded             = event.degraded,
+            reliability_score    = event.reliability.score,
+            gaze_score           = event.gaze.gaze_score,
+            time_score           = event.time.time_score,
+            answer_duration_ms   = event.time.answer_duration_ms,
+            keyword_candidates   = event.keywords.candidates,
+        )
+
+    # ── QuestionFeedback → FeedbackResponse ─────────────────────
+    @staticmethod
+    def _to_response(event: FeedbackEventRequest, domain: QuestionFeedback) -> FeedbackResponse:
         return FeedbackResponse(
+            intv_id                  = event.intv_id,          # ← 이벤트에서 직접
             intv_question_id         = domain.intv_question_id,
             status                   = domain.status,
             logic_score              = domain.logic_score,
@@ -29,4 +63,5 @@ class FeedbackService:
             time_score               = domain.time_score,
             answer_duration_ms       = domain.answer_duration_ms,
             keyword_count            = domain.keyword_count,
+            reliability              = domain.reliability_score,
         )

--- a/app/feedback/domain/feedback_model.py
+++ b/app/feedback/domain/feedback_model.py
@@ -29,7 +29,8 @@ class QuestionFeedback:
     time_score:                int                 = 0
     answer_duration_ms:        int                 = 0
     keyword_count:             int                 = 0
- # ! reliability
+    reliability_score:        int                 = 0
+
 
     @staticmethod
     def skipped(intv_question_id: int) -> "QuestionFeedback":
@@ -52,6 +53,7 @@ class QuestionFeedback:
         time_score:        int = 0,
         answer_duration_ms:int = 0,
         keyword_count:     int = 0,
+        reliability_score: int = 0,
     ) -> "QuestionFeedback":
         return QuestionFeedback(
             intv_question_id   = intv_question_id,
@@ -60,6 +62,7 @@ class QuestionFeedback:
             feedback_badges    = ["평가 실패"],
             gaze_score         = gaze_score,
             time_score         = time_score,
+            reliability_score  = reliability_score,
             answer_duration_ms = answer_duration_ms,
             keyword_count      = keyword_count,
         )

--- a/app/feedback/infrastructure/di.py
+++ b/app/feedback/infrastructure/di.py
@@ -1,20 +1,21 @@
-from pathlib import Path
 from langchain_openai import ChatOpenAI
-from app.feedback.application.service import FeedbackService
+
+from app.core.webhook.webhook_sender import WebhookSender
 from app.feedback.infrastructure.langchain_feedback_adapter import LangchainFeedbackAdapter
 from app.feedback.infrastructure.prompt_provider import FeedbackPromptProvider
+from app.feedback.infrastructure.webhook_callback_adapter import FeedbackWebhookCallbackAdapter
+from app.feedback.application.service import FeedbackService
 
 
 def _get_llm() -> ChatOpenAI:
-    return ChatOpenAI(
-        model="gpt-4o-mini",
-        temperature=0.0,
-        #api_key="invalid-key-for-test",
-        #infrastructure/di.py 임시 수정
-    )
-    
+    return ChatOpenAI(model="gpt-4o-mini", temperature=0.0)
+
+
 def get_feedback_service() -> FeedbackService:
-    llm             = _get_llm()
-    prompt_provider = FeedbackPromptProvider(version="v1")   # 버전 교체는 이 한 줄
-    adapter         = LangchainFeedbackAdapter(llm=llm, prompt_provider=prompt_provider)
-    return FeedbackService(feedback_port=adapter)
+    port = LangchainFeedbackAdapter(          # ← FeedbackAdapter → LangchainFeedbackAdapter
+        llm=_get_llm(),
+        prompt_provider=FeedbackPromptProvider(),
+    )
+    sender = WebhookSender()
+    callback = FeedbackWebhookCallbackAdapter(sender)
+    return FeedbackService(feedback_port=port, callback=callback)

--- a/app/feedback/infrastructure/langchain_feedback_adapter.py
+++ b/app/feedback/infrastructure/langchain_feedback_adapter.py
@@ -76,7 +76,7 @@ class LangchainFeedbackAdapter(FeedbackPort):
     )
     async def _invoke_with_retry(self, request: FeedbackRequest) -> FeedbackOutput:
         return await self._chain.ainvoke({
-            "question_text":        request.question_text,
+            "question_content":        request.question_content,
             "corrected_transcript": request.corrected_transcript,
         })
 

--- a/app/feedback/infrastructure/langchain_feedback_adapter.py
+++ b/app/feedback/infrastructure/langchain_feedback_adapter.py
@@ -28,7 +28,7 @@ class LangchainFeedbackAdapter(FeedbackPort):
 
     # 사전 차단 기준값
     MIN_TRANSCRIPT_LENGTH = 10
-    MIN_RELIABILITY_SCORE = 50
+    MIN_RELIABILITY_SCORE = 40
  
     def __init__(
         self,
@@ -84,6 +84,7 @@ class LangchainFeedbackAdapter(FeedbackPort):
     @staticmethod
     def _extract_media_scores(request: FeedbackRequest) -> dict:
         return {
+            "reliability_score": request.reliability_score,
             "gaze_score":         request.gaze_score,
             "time_score":         request.time_score,
             "answer_duration_ms": request.answer_duration_ms,

--- a/app/feedback/infrastructure/prompts/feedback_v1.yaml
+++ b/app/feedback/infrastructure/prompts/feedback_v1.yaml
@@ -36,5 +36,5 @@ system_prompt: |
   {format_instructions}
 
 human_prompt: |
-  [질문]: {question_text}
+  [질문]: {question_content}
   [답변]: {corrected_transcript}

--- a/app/feedback/infrastructure/webhook_callback_adapter.py
+++ b/app/feedback/infrastructure/webhook_callback_adapter.py
@@ -1,0 +1,16 @@
+# feedback/infrastructure/webhook_callback_adapter.py
+from app.core.webhook.webhook_sender import WebhookSender
+from app.feedback.application.port.callback_port import FeedbackCallbackPort
+from app.feedback.schema.response import FeedbackResponse
+
+class FeedbackWebhookCallbackAdapter(FeedbackCallbackPort):
+
+    def __init__(self, sender: WebhookSender) -> None:
+        self._sender = sender
+
+    async def send(self, url: str, payload: FeedbackResponse) -> None:
+        await self._sender.send(
+            url=url,
+            payload=payload.model_dump(by_alias=True),  # camelCase 직렬화
+            target="spring_webhook_feedback"
+        )

--- a/app/feedback/router.py
+++ b/app/feedback/router.py
@@ -1,24 +1,20 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends
 from app.core.schema import ApiResponse
 from app.feedback.application.service import FeedbackService
 from app.feedback.infrastructure.di import get_feedback_service
-from app.feedback.schema.request import FeedbackRequest
+from app.feedback.schema.request import FeedbackEventRequest
 from app.feedback.schema.response import FeedbackResponse
+
+
 
 router = APIRouter(prefix="/internal/v1/feedbacks", tags=["feedback"])
 
 
-@router.post("/generate", response_model=ApiResponse[FeedbackResponse])
+@router.post("/generate", status_code=202)
 async def generate_feedback(
-    request: FeedbackRequest,
+    request: FeedbackEventRequest,
+    background_tasks: BackgroundTasks,
     service: FeedbackService = Depends(get_feedback_service),
-) -> ApiResponse[FeedbackResponse]:
-
-    result = await service.generate_feedback(request)
-
-    return ApiResponse(
-        success = True,
-        code    = "FDBK-S000",
-        message = "success",
-        data    = result,
-    )
+):
+    background_tasks.add_task(service.run, request)
+    return {"success": True, "code": "S000", "message": "success", "data": None}

--- a/app/feedback/schema/request.py
+++ b/app/feedback/schema/request.py
@@ -2,11 +2,11 @@ from pydantic import BaseModel, Field, ConfigDict
 from pydantic.alias_generators import to_camel
 from typing import Optional
 
-
+# schema/request.py (이벤트 수신 모델)
 class KeywordCandidate(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
-        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+        populate_by_name=True,
     )
     
     term:     str
@@ -14,21 +14,61 @@ class KeywordCandidate(BaseModel):
     category: str
 
 
-class FeedbackRequest(BaseModel):
+class TranscriptInfo(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    raw_transcript: str
+    phonetic_transcript: str
+    corrected_transcript: str
+    # corrections, word_timestamps는 현재 피드백 생성에 불필요하면 Optional 처리
+    corrections: list = []
+    word_timestamps: list = []
+
+class KeywordsInfo(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    candidates: list[KeywordCandidate]
+
+class GazeInfo(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    gaze_score: int
+
+class TimeInfo(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    time_score: int
+    answer_duration_ms: int
+
+class ReliabilityInfo(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    score: int
+
+class FeedbackEventRequest(BaseModel):
     model_config = ConfigDict(
         alias_generator= to_camel,
-        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+        populate_by_name=True
     )
     
+    intv_id:     int
+    question_id: int
+    question_content: str
+    status: str
+    degraded: bool
+    transcript: TranscriptInfo
+    keywords: KeywordsInfo
+    gaze: GazeInfo
+    time: TimeInfo
+    reliability: ReliabilityInfo
+    
+    
+# ── 내부 LLM 어댑터 입력 모델 (service → adapter) ───────────────
+
+class FeedbackRequest(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     intv_question_id:     int
-    question_text:        str
+    question_content:     str
     corrected_transcript: str
-
-   
-    degraded:             bool = False
-    reliability_score:    int  = Field(default=0, ge=0, le=100)
-    gaze_score:           int  = Field(default=0,   ge=0, le=100)
-    time_score:           int  = Field(default=0,   ge=0, le=100)
-    answer_duration_ms:   int  = Field(default=0,   ge=0)
-
+    degraded:             bool  = False
+    reliability_score:    int   = Field(default=0, ge=0, le=100)
+    gaze_score:           int   = Field(default=0, ge=0, le=100)
+    time_score:           int   = Field(default=0, ge=0, le=100)
+    answer_duration_ms:   int   = Field(default=0, ge=0)
     keyword_candidates:   list[KeywordCandidate] = Field(default_factory=list)

--- a/app/feedback/schema/request.py
+++ b/app/feedback/schema/request.py
@@ -23,11 +23,10 @@ class FeedbackRequest(BaseModel):
     intv_question_id:     int
     question_text:        str
     corrected_transcript: str
-     # ! reliability
 
+   
     degraded:             bool = False
-    reliability_score:    int  = Field(default=100, ge=0, le=100)
-
+    reliability_score:    int  = Field(default=0, ge=0, le=100)
     gaze_score:           int  = Field(default=0,   ge=0, le=100)
     time_score:           int  = Field(default=0,   ge=0, le=100)
     answer_duration_ms:   int  = Field(default=0,   ge=0)

--- a/app/feedback/schema/response.py
+++ b/app/feedback/schema/response.py
@@ -3,26 +3,24 @@ from pydantic.alias_generators import to_camel
 from typing import Optional
 
 
+# schema/response.py
 class FeedbackResponse(BaseModel):
-    model_config = ConfigDict(
-        alias_generator=to_camel,
-        populate_by_name=True,
-        serialize_by_alias=True
-    )
-    
-    intv_question_id:          int
-    status:                    str
-    reliability_score: int=0
-    logic_score:               Optional[int] = None
-    answer_composition_score:  Optional[int] = None
-    characteristic:            Optional[str] = None
-    answer_summary:            Optional[str] = None
-    strength:                  Optional[str] = None
-    improvement:               Optional[str] = None
-    feedback_badges:           list[str]     = []
-    gaze_score:                int           = 0
-    time_score:                int           = 0
-    answer_duration_ms:        int           = 0
-    keyword_count:             int           = 0
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    model_config = {"use_enum_values": True}
+    intv_id: int                    
+    intv_question_id: int
+    status: str
+    logic_score: int
+    answer_composition_score: int
+    reliability: int                # ← reliability_score → reliability 로 변경
+    characteristic: str
+    answer_summary: str
+    strength: str
+    improvement: str
+    feedback_badges: list[str]
+    gaze_score: int
+    time_score: int
+    answer_duration_ms: int
+    keyword_count: int
+    error_message: str | None = None
+

--- a/app/feedback/schema/response.py
+++ b/app/feedback/schema/response.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 from typing import Optional
 
- # ! reliability
+
 class FeedbackResponse(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
@@ -12,6 +12,7 @@ class FeedbackResponse(BaseModel):
     
     intv_question_id:          int
     status:                    str
+    reliability_score: int=0
     logic_score:               Optional[int] = None
     answer_composition_score:  Optional[int] = None
     characteristic:            Optional[str] = None

--- a/app/main.py
+++ b/app/main.py
@@ -1,95 +1,57 @@
+
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
-
-from contextlib import asynccontextmanager
-from app.core import ConsulHelper
 from dotenv import load_dotenv
+
 from app.report.router import router as report_router
-
 from app.question.router import router as question_router
-import consul, os, uuid
-
-from app.core.schema import ApiResponse
 from app.feedback.router import router as feedback_router
+from app.core.schema import ApiResponse
+
+import os
 
 load_dotenv()
-
-# Configuration about consul client
-consul_host = os.getenv("CONSUL_HOST", "localhost")
-c = consul.Consul(host = consul_host, port = 8500)
-
-@asynccontextmanager
-async def lifespan(app: FastAPI) :
-    consul_helper = ConsulHelper(host="consul")
-    config = consul_helper.get_config("config/agent/settings")
-
-    SERVICE_ID = config.get("SERVICE_ID", "DEFAULT-SERVER")
-    EXTERNAL_HOST_IP = config.get("EXTERNAL_HOST_IP", "127.0.0.1")
-    EC2_PUBLIC_IP = config.get("EC2_PUBLIC_IP", "0.0.0.0")
-
-    # UUID를 사용하여 매번 다른 ID 생성
-    unique_id = f"{SERVICE_ID}:{uuid.uuid4()}" 
-
-    c.agent.service.register(
-        name = SERVICE_ID,
-        service_id = unique_id,
-        address = EXTERNAL_HOST_IP,
-        port = 8000,
-        check = consul.Check.http(f"http://{EC2_PUBLIC_IP}:8000/health", interval = "10s")
-    )
-    print("Consul 등록 완료")
-
-    yield # 서버 실행
-
-    c.agent.service.deregister(SERVICE_ID)
-    print("Consul 등록 해제")
 
 app = FastAPI(
     title="Interview AI Server",
     description="AI Interview Simulator - AI Features",
     version="0.1.0",
-    lifespan = lifespan
 )
 
+# ── 라우터 등록 ──────────────────────────────────────────────────
+app.include_router(question_router, prefix="/api/ai")
+app.include_router(feedback_router)
+app.include_router(report_router)
 
 # ── 헬스체크 ─────────────────────────────────────────────────────
-
-
 @app.get("/health")
 def health_check():
     return {"status": "ok", "message": "AI server is running"}
 
-
 # ── 전역 예외 핸들러 ─────────────────────────────────────────────
-
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     return JSONResponse(
         status_code=422,
         content=ApiResponse(
-            success = False,
-            code    = "CMMN-V001",
-            message = "입력값 유효성 검사에 실패했습니다.",
-            data    = None,
+            success=False,
+            code="CMMN-V001",
+            message="입력값 유효성 검사에 실패했습니다.",
+            data=None,
         ).model_dump(),
     )
-
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     return JSONResponse(
         status_code=500,
         content=ApiResponse(
-            success = False,
-            code    = "CMMN-I001",
-            message = "서버 내부 오류가 발생했습니다.",
-            data    = None,
+            success=False,
+            code="CMMN-I001",
+            message="서버 내부 오류가 발생했습니다.",
+            data=None,
         ).model_dump(),
     )
 
 
-# ── 라우터 등록 ──────────────────────────────────────────────────
-app.include_router(feedback_router)
-app.include_router(question_router)
-app.include_router(report_router)

--- a/app/question/application/service.py
+++ b/app/question/application/service.py
@@ -91,6 +91,6 @@ class QuestionService:
 
         # 8. Webhook 전송
         await self._callback.send(
-            url=request.callbackUrl,
+            url=request.callback,
             payload=payload,
         )

--- a/app/question/infrastructure/webhook_callback_adapter.py
+++ b/app/question/infrastructure/webhook_callback_adapter.py
@@ -13,6 +13,6 @@ class WebhookCallbackAdapter(CallbackPort):
     async def send(self, url: str, payload: QuestionCallbackPayload) -> None:
         await self._sender.send(
             url=     url,
-            payload= payload.model_dump(),
+            payload= payload.model_dump(by_alias=True),
             target=  TARGET,
         )

--- a/app/question/schema/request.py
+++ b/app/question/schema/request.py
@@ -15,15 +15,15 @@ class QuestionGenerateRequest(BaseModel):
         alias_generator=to_camel,
         populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
     )
-    intvId:      int
-    files:       list[FileEntry]
-    callbackUrl: str
-    resume_url: str
-    portfolio_url: str | None = None
-    self_introduction_url: str | None = None
-    job_role: str
+      intvId:      int
+      files:       list[FileEntry]
+      callbackUrl: str
+      resume_url: str
+      portfolio_url: str | None = None
+      self_introduction_url: str | None = None
+      job_role: str
 
-    def get_file_key(self, file_type: str) -> str | None:
+def get_file_key(self, file_type: str) -> str | None:
         for f in self.files:
             if f.fileType == file_type:
                 return f.fileKey

--- a/app/question/schema/request.py
+++ b/app/question/schema/request.py
@@ -17,7 +17,7 @@ class QuestionGenerateRequest(BaseModel):
     )
       intvId:      int
       files:       list[FileEntry]
-      callbackUrl: str
+      callback: str
       resume_url: str
       portfolio_url: str | None = None
       self_introduction_url: str | None = None

--- a/app/report/schema/request.py
+++ b/app/report/schema/request.py
@@ -3,27 +3,28 @@ from pydantic import BaseModel, model_validator,ConfigDict
 from typing import Optional
 from pydantic.alias_generators import to_camel
 
-class FeedbackStatus(str, Enum):
-        model_config = ConfigDict(
+class FeedbackStatus(str, Enum): 
+    model_config = ConfigDict(
         alias_generator=to_camel,
-        populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
+        populate_by_name=True, 
     )
     SUCCEED = "SUCCEED"
     FAILED = "FAILED"
 
 
 class FeedbackItem(BaseModel):
-     
-    intv_question_id: int 
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True, # Spring이 보낸 camelCase를 받아들임
-    )
-    # ! reliability    
+    )     
+    intv_question_id: int 
+
+     
     intv_question_id: int
     index: int 
     question: str
     status: FeedbackStatus
+    reliability_score: int
     logic_score: int
     answer_composition_score: int
     answer_summary: str

--- a/app/report/schema/response.py
+++ b/app/report/schema/response.py
@@ -50,7 +50,8 @@ class ReportResponse(BaseModel):
     answered_count: int
     avg_answer_duration_ms: int
     created_at: datetime
-    # reliability
+    reliability_score: int
+
     report_accuracy: str
     competency_scores: CompetencyScores
     total_score: int

--- a/tests.md
+++ b/tests.md
@@ -36,7 +36,7 @@ PS C:\Users\user\Documents\GitHub\gamyeon-AI> uv run python callback_receiver.py
 ```
 {
   "intv_question_id": 101,
-  "question_text": "본인의 강점에 대해 설명해주세요.",
+  "question_content": "본인의 강점에 대해 설명해주세요.",
   "corrected_transcript": "제 강점은 문제 해결 능력입니다. 프로젝트 진행 시 협업을 통해 효율적인 결과를 만들어냅니다.",
   "degraded": false,
   "reliability_score": 95,

--- a/tests.md
+++ b/tests.md
@@ -12,7 +12,7 @@ PS C:\Users\user\Documents\GitHub\gamyeon-AI> uv run python callback_receiver.py
       "fileKey": "sample/resume.pdf"
     }
   ],
-  "callbackUrl": "http://127.0.0.1:9000/internal/v1/questions/callback"
+  "callback": "http://127.0.0.1:9000/internal/v1/questions/callback"
 }
 
 ```


### PR DESCRIPTION
피드백 내부 메세지, api 내용 다른거 수정했습니다. 
웹훅 내용도 구현했습니다. 

해당 PR 머지된후, 이벤트 리스터 구현한거 pr 올리겠습니다. 

### 웹훅이 나가는 흐름

***

## 1. media 이벤트 수신

1. media 도메인이 내부 이벤트를 발행합니다.

   ```python
   from app.core.events import bus
   from app.core.events.signals import media_completed

   bus.emit(media_completed, payload=feedback_event_payload)
   ```

2. `startup`에서 등록한 리스너가 이 시그널을 구독합니다.

   ```python
   # app/feedback/infrastructure/event_listener.py
   from app.core.events import bus
   from app.core.events.signals import media_completed

   def register_feedback_listeners(service: FeedbackService) -> None:
       bus.subscribe(media_completed, service.on_media_completed)
   ```

3. FastAPI 기동 시 리스너를 붙입니다.

   ```python
   # app/main.py
   from app.feedback.infrastructure.event_listener import register_feedback_listeners
   from app.feedback.infrastructure.di import get_feedback_service

   @app.on_event("startup")
   async def startup():
       service = get_feedback_service()
       register_feedback_listeners(service)
   ```

4. 이벤트가 오면 `FeedbackService.on_media_completed`가 호출됩니다.

   ```python
   # service.py
   async def on_media_completed(self, payload: dict) -> None:
       event = FeedbackEventRequest.model_validate(payload)  # camelCase → snake_case 매핑
       await self.run(event)
   ```

***

## 2. LLM으로 피드백 생성

5. `run()`이 실제 피드백 생성과 콜백 전송을 담당합니다.

   ```python
   async def run(self, event: FeedbackEventRequest) -> None:
       payload = await self._build_payload(event)  # 성공/실패에 따라 FeedbackResponse 생성
       await self._callback.send(
           url=settings.FEEDBACK_SPRING_WEBHOOK_URL,
           payload=payload,
       )
   ```

6. `_build_payload()` 안에서:

   ```python
   async def _build_payload(self, event: FeedbackEventRequest) -> FeedbackResponse:
       try:
           request = self._to_request(event)  # FeedbackEventRequest → FeedbackRequest
           result: QuestionFeedback = await self._port.generate_feedback(request)
           return self._to_response(event, result)  # 도메인 → Response DTO
       except Exception as e:
           return FeedbackResponse(
               intv_id          = event.intv_id,
               intv_question_id = event.question_id,
               status           = "FAILED",
               error_message    = str(e),
           )
   ```

7. 여기서 `self._port`는 `LangchainFeedbackAdapter`입니다.

   ```python
   # di.py
   port = LangchainFeedbackAdapter(
       llm=_get_llm(),
       prompt_provider=FeedbackPromptProvider(),
   )
   service = FeedbackService(feedback_port=port, callback=callback)
   ```

   이 어댑터가 LLM을 호출해 `QuestionFeedback` 도메인을 만들어 줍니다.

***

## 3. Spring으로 웹훅 전송

8. `FeedbackService.run()` 마지막 줄에서 `callback.send()`가 호출됩니다.

   ```python
   await self._callback.send(
       url=settings.FEEDBACK_SPRING_WEBHOOK_URL,
       payload=payload,
   )
   ```

9. `FeedbackWebhookCallbackAdapter`가 여기서 실제 웹훅 전송용 dict로 직렬화합니다.

   ```python
   # app/feedback/infrastructure/webhook_callback_adapter.py
   class FeedbackWebhookCallbackAdapter(FeedbackCallbackPort):

       def __init__(self, sender: WebhookSender) -> None:
           self._sender = sender

       async def send(self, url: str, payload: FeedbackResponse) -> None:
           await self._sender.send(
               url=url,
               payload=payload.model_dump(by_alias=True),  # snake_case → camelCase
               target="spring_webhook_feedback",
           )
   ```

   여기서 `by_alias=True` 덕분에:

   - `intv_id` → `intvId`
   - `intv_question_id` → `intvQuestionId`
   - `answer_duration_ms` → `answerDurationMs`
   - `reliability` → `reliability`

   처럼 JSON 키가 모두 camelCase로 변환됩니다.

10. 실제 HTTP 호출은 `WebhookSender`가 담당합니다.

   ```python
   # app/core/webhook_sender.py (요약 형태)
   async def send(self, url: str, payload: dict, target: str) -> None:
       # 2xx: 성공 로그
       # 5xx: 최대 3회 재시도 (tenacity)
       # 4xx or 재시도 실패: DLQ JSON 로그 남김
       ...
   ```

11. `.env`에서 설정한 URL로 전송됩니다.

   ```env
   FEEDBACK_SPRING_WEBHOOK_URL=https://spring-server/internal/v1/feedbacks/callback
   ```

   그래서 최종적으로는:

   - HTTP 메서드: `POST`
   - URL: `https://spring-server/internal/v1/feedbacks/callback`
   - Body(JSON):

     ```json
     {
       "intvId": 31,
       "intvQuestionId": 123,
       "status": "SUCCEED",
       "logicScore": 85,
       "answerCompositionScore": 70,
       "reliability": 80,
       "characteristic": "...",
       "answerSummary": "...",
       "strength": "...",
       "improvement": "...",
       "feedbackBadges": ["..."],
       "gazeScore": 82,
       "timeScore": 91,
       "answerDurationMs": 54500,
       "keywordCount": 2
     }
     ```

피드백 기능은:

- media 이벤트를 blinker 기반 내부 이벤트로 받고,
- LLM으로 문항별 피드백을 생성해서,
- 설정된 `FEEDBACK_SPRING_WEBHOOK_URL`로 camelCase JSON을 웹훅 POST 하는 구조입니다.

\\